### PR TITLE
feat: add PR preview environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,15 +5,11 @@ on:
     branches:
       - main
 
-# GitHub Pagesへのデプロイに必要な権限を設定
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
-# 同時に実行されるデプロイを防ぐ
 concurrency:
-  group: "pages"
+  group: pages-main
   cancel-in-progress: false
 
 jobs:
@@ -38,22 +34,9 @@ jobs:
         env:
           NODE_ENV: production
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./dist
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          keep_files: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: pages-main
+  group: gh-pages
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,116 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build with PR-specific base path
+        env:
+          VITE_BASE_PATH: /memo-list/pr-${{ github.event.number }}/
+        run: npm run build
+
+      - name: Deploy PR preview to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          destination_dir: pr-${{ github.event.number }}
+          keep_files: true
+
+      - name: Post preview URL comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            const previewUrl = `https://keigo-hisazumi.github.io/memo-list/pr-${prNumber}/`;
+            const marker = '<!-- pr-preview -->';
+            const body = [
+              marker,
+              '## プレビュー環境 🚀',
+              '',
+              `| | |`,
+              `|---|---|`,
+              `| **プレビューURL** | [${previewUrl}](${previewUrl}) |`,
+              `| **コミット** | \`${context.sha.slice(0, 7)}\` |`,
+              '',
+              '*コードをプッシュするたびに自動更新されます。*',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Remove preview directory from gh-pages
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if ! git ls-remote --exit-code origin gh-pages; then
+            echo "gh-pages branch does not exist, skipping cleanup"
+            exit 0
+          fi
+
+          git fetch origin gh-pages
+          git checkout gh-pages
+
+          if [ -d "pr-${{ github.event.number }}" ]; then
+            git rm -rf "pr-${{ github.event.number }}"
+            git commit -m "chore: remove PR #${{ github.event.number }} preview"
+            git push origin gh-pages
+          else
+            echo "Preview directory pr-${{ github.event.number }} not found, skipping"
+          fi

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -10,8 +10,8 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: pr-preview-${{ github.event.number }}
-  cancel-in-progress: true
+  group: gh-pages
+  cancel-in-progress: false
 
 jobs:
   deploy-preview:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,5 +15,5 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   },
-  base: process.env.NODE_ENV === 'production' ? '/memo-list/' : '/',
+  base: process.env.VITE_BASE_PATH || (process.env.NODE_ENV === 'production' ? '/memo-list/' : '/'),
 })


### PR DESCRIPTION
## Summary

sns-memoのPRプレビュー構成を参考に、memo-listにもPRごとのプレビュー環境を追加しました。

- `.github/workflows/pr-preview.yml` を新規追加
  - PR open / synchronize / reopened で `gh-pages` 配下の `pr-<番号>/` にビルド成果物を公開
  - PRに `https://keigo-hisazumi.github.io/memo-list/pr-<番号>/` のURLをコメント（既存コメントがあれば更新）
  - PR close 時に該当ディレクトリを `gh-pages` から削除
- `vite.config.ts` で `VITE_BASE_PATH` を優先するように変更し、PRごとに base path を切り替え可能に
- `.github/workflows/deploy.yml` を `peaceiris/actions-gh-pages@v4` 方式へ移行
  - 公式の `actions/deploy-pages` のままだと、本番デプロイがPagesのartifactを丸ごと差し替えるためPRプレビュー用のディレクトリが消えてしまいます
  - 本番とPRプレビューを同じ `gh-pages` ブランチ上に共存させるため、本番側もpeaceirisアクションに揃えました（`keep_files: true`）

## ⚠️ 必要な手動設定

このPRをマージする前後で、リポジトリの **Settings → Pages** の **Source** を以下に変更してください：

- **Deploy from a branch** を選択
- Branch: `gh-pages` / `/ (root)`

現状の "GitHub Actions" のままだとgh-pagesブランチへの変更がPagesに反映されません。

## Test plan

- [ ] このPRに対してプレビュー用コメント（プレビューURLを含む）が自動投稿されることを確認
- [ ] 上記URLにアクセスし、PR時点のビルドが表示されることを確認
- [ ] このPRに追加コミットしたとき、コメントが更新されビルドも更新されることを確認
- [ ] PRをcloseしたとき、`gh-pages` から `pr-<番号>/` ディレクトリが削除されることを確認
- [ ] mainマージ後、本番（`https://keigo-hisazumi.github.io/memo-list/`）が引き続き正常表示されることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ak7uVWetPK5ZsakBFh8S5o)_