### PR TITLE
fix: ページリロード時にログインが保持されない問題を修正

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,9 +15,12 @@ const app = createApp(App)
 const pinia = createPinia()
 
 app.use(pinia)
-app.use(router)
 
+// Firebase の認証状態が確定してからルーターをマウントすることで、
+// ページリロード時に onAuthStateChanged が完了する前にルートガードが
+// 走って currentUser が null と判定されるレースコンディションを防ぐ
 const authStore = useAuthStore()
 authStore.initAuth().then(() => {
+  app.use(router)
   app.mount('#app')
 })


### PR DESCRIPTION
## 問題

ページをリロードすると、ログイン済みのユーザーがログインページにリダイレクトされ、ログイン状態が保持されない。

## 原因

`main.ts` で `app.use(router)` を `initAuth()` の完了前に呼び出していたことによるレースコンディション。

Vue Router 4 では **`app.use(router)` の時点で初期ナビゲーションが開始される**。そのため、Firebase の `onAuthStateChanged` が auth 状態（`currentUser`）を復元する前にルートガードが実行され、`currentUser === null` と判定されてログインページへリダイレクトされていた。

```
【修正前の実行順序】
1. app.use(router)          ← 初期ナビゲーション開始
2. beforeEach ガード実行    ← currentUser は null → /login へリダイレクト ❌
3. initAuth() 完了          ← currentUser が復元される（が、すでに遅い）
4. app.mount('#app')
```

## 修正内容

`app.use(router)` と `app.mount('#app')` を `initAuth()` の完了後（`.then()` 内）に移動した。

```
【修正後の実行順序】
1. initAuth() 完了          ← currentUser が正しく設定される ✅
2. app.use(router)          ← 初期ナビゲーション開始
3. beforeEach ガード実行    ← currentUser が正しい値 → 正常に遷移
4. app.mount('#app')
```

## 変更ファイル

- `src/main.ts`: `app.use(router)` を `initAuth().then()` の中へ移動

https://claude.ai/code/session_015dqhT7ZTNvhMebnakziBAM

---
_Generated by [Claude Code](https://claude.ai/code/session_015dqhT7ZTNvhMebnakziBAM)_