### PR TITLE
feat: ハンバーガーメニュー・ダーク/ライトモード切り替えを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="メモリスト">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="format-detection" content="telephone=no,email=no,address=no">
     <meta name="description" content="シンプルで使いやすいメモアプリ">
     <title>メモリスト - Memo List</title>
   </head>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,17 @@
 <script setup lang="ts">
-import { watch } from 'vue'
+import { watch, onMounted } from 'vue'
 import { RouterView } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useMemoStore } from '@/stores/memo'
+import { useThemeStore } from '@/stores/theme'
 
 const authStore = useAuthStore()
 const memoStore = useMemoStore()
+const themeStore = useThemeStore()
+
+onMounted(() => {
+  themeStore.initTheme()
+})
 
 watch(
   () => authStore.currentUser,

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -34,10 +34,36 @@
   --color-text: var(--vt-c-text-light-1);
 
   --section-gap: 160px;
+
+  /* App-specific variables (light mode defaults) */
+  --app-bg: #ffffff;
+  --app-bg-soft: #f5f5f5;
+  --app-header-bg: #f0fdf7;
+  --app-header-border: #d1fae5;
+  --app-border: #e0e0e0;
+  --app-text: #333333;
+  --app-text-secondary: #666666;
+  --app-text-muted: #999999;
+  --app-text-placeholder: #cccccc;
+  --app-input-bg: #ffffff;
+  --app-active-bg: #f0fdf7;
+  --app-active-border: #42b883;
+  --app-category-bg: #e3f2fd;
+  --app-category-text: #1976d2;
+  --app-accent: #42b883;
+  --app-accent-hover: #359268;
+  --app-shadow: rgba(0, 0, 0, 0.1);
+  --app-menu-bg: #ffffff;
+  --app-menu-shadow: rgba(0, 0, 0, 0.15);
+  --app-menu-hover: #f5f5f5;
+  --app-delete-hover-bg: #fff0f0;
+  --app-delete-hover-text: #d32f2f;
+  --app-logout-hover-text: #e53935;
 }
 
+/* System dark mode preference */
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not(.light) {
     --color-background: var(--vt-c-black);
     --color-background-soft: var(--vt-c-black-soft);
     --color-background-mute: var(--vt-c-black-mute);
@@ -47,7 +73,102 @@
 
     --color-heading: var(--vt-c-text-dark-1);
     --color-text: var(--vt-c-text-dark-2);
+
+    /* App-specific dark mode */
+    --app-bg: #1e1e1e;
+    --app-bg-soft: #252525;
+    --app-header-bg: #1a2822;
+    --app-header-border: #2a4035;
+    --app-border: #3a3a3a;
+    --app-text: #e0e0e0;
+    --app-text-secondary: #a0a0a0;
+    --app-text-muted: #707070;
+    --app-text-placeholder: #555555;
+    --app-input-bg: #252525;
+    --app-active-bg: #1a2e22;
+    --app-active-border: #42b883;
+    --app-category-bg: #1a2a40;
+    --app-category-text: #64b5f6;
+    --app-shadow: rgba(0, 0, 0, 0.3);
+    --app-menu-bg: #2a2a2a;
+    --app-menu-shadow: rgba(0, 0, 0, 0.4);
+    --app-menu-hover: #333333;
+    --app-delete-hover-bg: #3a1a1a;
+    --app-delete-hover-text: #ef5350;
+    --app-logout-hover-text: #ef5350;
   }
+}
+
+/* Manual dark mode class (overrides both light and system preference) */
+:root.dark {
+  --color-background: var(--vt-c-black);
+  --color-background-soft: var(--vt-c-black-soft);
+  --color-background-mute: var(--vt-c-black-mute);
+
+  --color-border: var(--vt-c-divider-dark-2);
+  --color-border-hover: var(--vt-c-divider-dark-1);
+
+  --color-heading: var(--vt-c-text-dark-1);
+  --color-text: var(--vt-c-text-dark-2);
+
+  /* App-specific dark mode */
+  --app-bg: #1e1e1e;
+  --app-bg-soft: #252525;
+  --app-header-bg: #1a2822;
+  --app-header-border: #2a4035;
+  --app-border: #3a3a3a;
+  --app-text: #e0e0e0;
+  --app-text-secondary: #a0a0a0;
+  --app-text-muted: #707070;
+  --app-text-placeholder: #555555;
+  --app-input-bg: #252525;
+  --app-active-bg: #1a2e22;
+  --app-active-border: #42b883;
+  --app-category-bg: #1a2a40;
+  --app-category-text: #64b5f6;
+  --app-shadow: rgba(0, 0, 0, 0.3);
+  --app-menu-bg: #2a2a2a;
+  --app-menu-shadow: rgba(0, 0, 0, 0.4);
+  --app-menu-hover: #333333;
+  --app-delete-hover-bg: #3a1a1a;
+  --app-delete-hover-text: #ef5350;
+  --app-logout-hover-text: #ef5350;
+}
+
+/* Manual light mode class (overrides system dark preference) */
+:root.light {
+  --color-background: var(--vt-c-white);
+  --color-background-soft: var(--vt-c-white-soft);
+  --color-background-mute: var(--vt-c-white-mute);
+
+  --color-border: var(--vt-c-divider-light-2);
+  --color-border-hover: var(--vt-c-divider-light-1);
+
+  --color-heading: var(--vt-c-text-light-1);
+  --color-text: var(--vt-c-text-light-1);
+
+  /* App-specific light mode */
+  --app-bg: #ffffff;
+  --app-bg-soft: #f5f5f5;
+  --app-header-bg: #f0fdf7;
+  --app-header-border: #d1fae5;
+  --app-border: #e0e0e0;
+  --app-text: #333333;
+  --app-text-secondary: #666666;
+  --app-text-muted: #999999;
+  --app-text-placeholder: #cccccc;
+  --app-input-bg: #ffffff;
+  --app-active-bg: #f0fdf7;
+  --app-active-border: #42b883;
+  --app-category-bg: #e3f2fd;
+  --app-category-text: #1976d2;
+  --app-shadow: rgba(0, 0, 0, 0.1);
+  --app-menu-bg: #ffffff;
+  --app-menu-shadow: rgba(0, 0, 0, 0.15);
+  --app-menu-hover: #f5f5f5;
+  --app-delete-hover-bg: #fff0f0;
+  --app-delete-hover-text: #d32f2f;
+  --app-logout-hover-text: #e53935;
 }
 
 *,
@@ -63,8 +184,8 @@ body {
   color: var(--color-text);
   background: var(--color-background);
   transition:
-    color 0.5s,
-    background-color 0.5s;
+    color 0.3s,
+    background-color 0.3s;
   line-height: 1.6;
   font-family:
     Inter,

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -179,6 +179,20 @@
   font-weight: normal;
 }
 
+/* テーマ切り替え時だけ全要素に一括トランジションを適用 */
+html.theme-transitioning *,
+html.theme-transitioning *::before,
+html.theme-transitioning *::after {
+  transition:
+    background-color 0.35s ease,
+    background 0.35s ease,
+    color 0.35s ease,
+    border-color 0.35s ease,
+    box-shadow 0.35s ease,
+    fill 0.35s ease,
+    stroke 0.35s ease !important;
+}
+
 body {
   min-height: 100vh;
   color: var(--color-text);

--- a/src/components/HamburgerMenu.vue
+++ b/src/components/HamburgerMenu.vue
@@ -99,11 +99,7 @@ function closeMenu() {
 }
 
 function handleThemeToggle() {
-  // メニューを閉じてからテーマを切り替え（閉じるアニメーション完了後に変更）
-  closeMenu()
-  setTimeout(() => {
-    themeStore.toggleTheme()
-  }, 180)
+  themeStore.toggleTheme()
 }
 
 function handleLogout() {

--- a/src/components/HamburgerMenu.vue
+++ b/src/components/HamburgerMenu.vue
@@ -218,6 +218,7 @@ onUnmounted(() => {
   white-space: nowrap;
   max-width: 180px;
   text-decoration: none;
+  -webkit-touch-callout: none;
 }
 
 .account-avatar {

--- a/src/components/HamburgerMenu.vue
+++ b/src/components/HamburgerMenu.vue
@@ -204,6 +204,20 @@ onUnmounted(() => {
   padding: 1rem 1.25rem;
   cursor: default;
   pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.account-name {
+  font-size: 0.85rem;
+  color: var(--app-text);
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 180px;
+  text-decoration: none;
 }
 
 .account-avatar {
@@ -219,15 +233,6 @@ onUnmounted(() => {
   flex-shrink: 0;
 }
 
-.account-name {
-  font-size: 0.85rem;
-  color: var(--app-text);
-  font-weight: 500;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 180px;
-}
 
 /* 区切り線 */
 .menu-divider {

--- a/src/components/HamburgerMenu.vue
+++ b/src/components/HamburgerMenu.vue
@@ -37,8 +37,11 @@
         <!-- テーマ切り替え -->
         <button class="menu-item" @click="handleThemeToggle">
           <span class="menu-item-icon">
-            <!-- ダークモード時: 太陽アイコン / ライトモード時: 月アイコン -->
+            <!-- ダークモード時: 月アイコン / ライトモード時: 太陽アイコン（現在のモードを表示） -->
             <svg v-if="themeStore.isDark" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+            </svg>
+            <svg v-else width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <circle cx="12" cy="12" r="5"/>
               <line x1="12" y1="1" x2="12" y2="3"/>
               <line x1="12" y1="21" x2="12" y2="23"/>
@@ -49,11 +52,8 @@
               <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
               <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
             </svg>
-            <svg v-else width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
-            </svg>
           </span>
-          <span>{{ themeStore.isDark ? 'ライトモード' : 'ダークモード' }}</span>
+          <span>{{ themeStore.isDark ? 'ダークモード' : 'ライトモード' }}</span>
         </button>
 
         <div class="menu-divider"></div>
@@ -196,12 +196,14 @@ onUnmounted(() => {
   z-index: 200;
 }
 
-/* アカウント情報 */
+/* アカウント情報（非インタラクティブ） */
 .menu-account {
   display: flex;
   align-items: center;
   gap: 0.75rem;
   padding: 1rem 1.25rem;
+  cursor: default;
+  pointer-events: none;
 }
 
 .account-avatar {

--- a/src/components/HamburgerMenu.vue
+++ b/src/components/HamburgerMenu.vue
@@ -1,0 +1,310 @@
+<template>
+  <div class="hamburger-menu" ref="menuRef">
+    <!-- ハンバーガーボタン -->
+    <button
+      class="hamburger-btn"
+      :class="{ open: isOpen }"
+      @click="toggleMenu"
+      aria-label="メニューを開く"
+    >
+      <span class="bar"></span>
+      <span class="bar"></span>
+      <span class="bar"></span>
+    </button>
+
+    <!-- オーバーレイ -->
+    <Transition name="fade">
+      <div v-if="isOpen" class="menu-overlay" @click="closeMenu"></div>
+    </Transition>
+
+    <!-- ドロップダウンメニュー -->
+    <Transition name="slide-down">
+      <div v-if="isOpen" class="menu-dropdown">
+
+        <!-- アカウント情報 -->
+        <div class="menu-account">
+          <div class="account-avatar">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
+              <circle cx="12" cy="7" r="4"/>
+            </svg>
+          </div>
+          <span class="account-name">{{ authStore.currentUser?.email }}</span>
+        </div>
+
+        <div class="menu-divider"></div>
+
+        <!-- テーマ切り替え -->
+        <button class="menu-item" @click="handleThemeToggle">
+          <span class="menu-item-icon">
+            <!-- ダークモード時: 太陽アイコン / ライトモード時: 月アイコン -->
+            <svg v-if="themeStore.isDark" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="5"/>
+              <line x1="12" y1="1" x2="12" y2="3"/>
+              <line x1="12" y1="21" x2="12" y2="23"/>
+              <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+              <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+              <line x1="1" y1="12" x2="3" y2="12"/>
+              <line x1="21" y1="12" x2="23" y2="12"/>
+              <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+              <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+            </svg>
+            <svg v-else width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+            </svg>
+          </span>
+          <span>{{ themeStore.isDark ? 'ライトモード' : 'ダークモード' }}</span>
+        </button>
+
+        <div class="menu-divider"></div>
+
+        <!-- ログアウト -->
+        <button class="menu-item logout-item" @click="handleLogout">
+          <span class="menu-item-icon">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
+              <polyline points="16 17 21 12 16 7"/>
+              <line x1="21" y1="12" x2="9" y2="12"/>
+            </svg>
+          </span>
+          <span>ログアウト</span>
+        </button>
+
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+import { useAuthStore } from '@/stores/auth'
+import { useThemeStore } from '@/stores/theme'
+
+const emit = defineEmits<{
+  logout: []
+}>()
+
+const authStore = useAuthStore()
+const themeStore = useThemeStore()
+
+const isOpen = ref(false)
+const menuRef = ref<HTMLElement | null>(null)
+
+function toggleMenu() {
+  isOpen.value = !isOpen.value
+}
+
+function closeMenu() {
+  isOpen.value = false
+}
+
+function handleThemeToggle() {
+  themeStore.toggleTheme()
+  closeMenu()
+}
+
+function handleLogout() {
+  closeMenu()
+  emit('logout')
+}
+
+// メニュー外クリックで閉じる
+function handleClickOutside(event: MouseEvent) {
+  if (menuRef.value && !menuRef.value.contains(event.target as Node)) {
+    closeMenu()
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('mousedown', handleClickOutside)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('mousedown', handleClickOutside)
+})
+</script>
+
+<style scoped>
+.hamburger-menu {
+  position: relative;
+  z-index: 100;
+}
+
+/* ハンバーガーボタン */
+.hamburger-btn {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 5px;
+  width: 36px;
+  height: 36px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  padding: 6px;
+  transition: background 0.2s;
+}
+
+.hamburger-btn:hover {
+  background: var(--app-menu-hover);
+}
+
+.bar {
+  display: block;
+  width: 20px;
+  height: 2px;
+  background: var(--app-text-secondary);
+  border-radius: 2px;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+  transform-origin: center;
+}
+
+/* バーのX変形アニメーション */
+.hamburger-btn.open .bar:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+
+.hamburger-btn.open .bar:nth-child(2) {
+  opacity: 0;
+  transform: scaleX(0);
+}
+
+.hamburger-btn.open .bar:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
+}
+
+/* オーバーレイ */
+.menu-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 99;
+}
+
+/* ドロップダウンメニュー */
+.menu-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 240px;
+  background: var(--app-menu-bg);
+  border: 1px solid var(--app-border);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px var(--app-menu-shadow);
+  overflow: hidden;
+  z-index: 200;
+}
+
+/* アカウント情報 */
+.menu-account {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+}
+
+.account-avatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: var(--app-header-bg);
+  border: 1px solid var(--app-border);
+  border-radius: 50%;
+  color: var(--app-accent);
+  flex-shrink: 0;
+}
+
+.account-name {
+  font-size: 0.85rem;
+  color: var(--app-text);
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 180px;
+}
+
+/* 区切り線 */
+.menu-divider {
+  height: 1px;
+  background: var(--app-border);
+  margin: 0;
+}
+
+/* メニューアイテム */
+.menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.75rem 1.25rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 0.875rem;
+  color: var(--app-text-secondary);
+  text-align: left;
+  transition: background 0.15s, color 0.15s;
+  font-family: inherit;
+}
+
+.menu-item:hover {
+  background: var(--app-menu-hover);
+  color: var(--app-text);
+}
+
+.menu-item-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  flex-shrink: 0;
+  color: var(--app-text-muted);
+  transition: color 0.15s;
+}
+
+.menu-item:hover .menu-item-icon {
+  color: var(--app-text-secondary);
+}
+
+/* ログアウトボタン */
+.logout-item:hover {
+  color: var(--app-logout-hover-text);
+}
+
+.logout-item:hover .menu-item-icon {
+  color: var(--app-logout-hover-text);
+}
+
+/* トランジション */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+.slide-down-enter-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.slide-down-leave-active {
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.slide-down-enter-from {
+  opacity: 0;
+  transform: translateY(-8px);
+}
+
+.slide-down-leave-to {
+  opacity: 0;
+  transform: translateY(-4px);
+}
+</style>

--- a/src/components/HamburgerMenu.vue
+++ b/src/components/HamburgerMenu.vue
@@ -99,8 +99,11 @@ function closeMenu() {
 }
 
 function handleThemeToggle() {
-  themeStore.toggleTheme()
+  // メニューを閉じてからテーマを切り替え（閉じるアニメーション完了後に変更）
   closeMenu()
+  setTimeout(() => {
+    themeStore.toggleTheme()
+  }, 180)
 }
 
 function handleLogout() {

--- a/src/components/MemoEditor.vue
+++ b/src/components/MemoEditor.vue
@@ -40,7 +40,7 @@
           @input="handleUpdate"
         />
         <span class="meta-date">
-          作成: {{ formatDate(memo.createdAt) }} / 
+          作成: {{ formatDate(memo.createdAt) }} /
           更新: {{ formatDate(memo.updatedAt) }}
         </span>
       </div>
@@ -91,7 +91,7 @@ watch(() => props.memo, (newMemo) => {
 
 function handleUpdate() {
   if (!props.memo) return
-  
+
   emit('update', props.memo.id, {
     title: localTitle.value,
     content: localContent.value,
@@ -101,7 +101,7 @@ function handleUpdate() {
 
 function handleDelete() {
   if (!props.memo) return
-  
+
   if (confirm(`「${props.memo.title || '無題のメモ'}」を削除してもよろしいですか？`)) {
     emit('delete', props.memo.id)
   }
@@ -123,7 +123,8 @@ function formatDate(date: Date): string {
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: white;
+  background: var(--app-bg);
+  transition: background 0.3s;
 }
 
 .no-selection {
@@ -131,7 +132,8 @@ function formatDate(date: Date): string {
   align-items: center;
   justify-content: center;
   height: 100%;
-  color: #999;
+  color: var(--app-text-muted);
+  transition: color 0.3s;
 }
 
 .no-selection-content {
@@ -159,7 +161,8 @@ function formatDate(date: Date): string {
   align-items: center;
   gap: 1rem;
   padding: 1.5rem 1.5rem 0.5rem;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--app-border);
+  transition: border-color 0.3s;
 }
 
 .title-input {
@@ -169,11 +172,13 @@ function formatDate(date: Date): string {
   border: none;
   outline: none;
   padding: 0.5rem;
-  color: #333;
+  color: var(--app-text);
+  background: transparent;
+  transition: color 0.3s;
 }
 
 .title-input::placeholder {
-  color: #ccc;
+  color: var(--app-text-placeholder);
 }
 
 .editor-actions {
@@ -187,13 +192,13 @@ function formatDate(date: Date): string {
   border: none;
   border-radius: 4px;
   cursor: pointer;
-  color: #666;
+  color: var(--app-text-muted);
   transition: all 0.2s;
 }
 
 .btn-delete:hover {
-  background: #fee;
-  color: #d32f2f;
+  background: var(--app-delete-hover-bg);
+  color: var(--app-delete-hover-text);
 }
 
 .editor-meta {
@@ -201,25 +206,34 @@ function formatDate(date: Date): string {
   align-items: center;
   gap: 1rem;
   padding: 0.5rem 1.5rem;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--app-border);
+  transition: border-color 0.3s;
 }
 
 .category-input {
   padding: 0.25rem 0.75rem;
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--app-border);
   border-radius: 12px;
   font-size: 0.875rem;
   outline: none;
   max-width: 200px;
+  background: var(--app-input-bg);
+  color: var(--app-text);
+  transition: background 0.3s, border-color 0.3s, color 0.3s;
 }
 
 .category-input:focus {
-  border-color: #42b883;
+  border-color: var(--app-accent);
+}
+
+.category-input::placeholder {
+  color: var(--app-text-placeholder);
 }
 
 .meta-date {
   font-size: 0.75rem;
-  color: #999;
+  color: var(--app-text-muted);
+  transition: color 0.3s;
 }
 
 .editor-content {
@@ -237,10 +251,12 @@ function formatDate(date: Date): string {
   font-family: inherit;
   line-height: 1.6;
   resize: none;
-  color: #333;
+  color: var(--app-text);
+  background: transparent;
+  transition: color 0.3s;
 }
 
 .content-textarea::placeholder {
-  color: #ccc;
+  color: var(--app-text-placeholder);
 }
 </style>

--- a/src/components/MemoList.vue
+++ b/src/components/MemoList.vue
@@ -64,7 +64,7 @@ function formatDate(date: Date): string {
   if (minutes < 60) return `${minutes}分前`
   if (hours < 24) return `${hours}時間前`
   if (days < 7) return `${days}日前`
-  
+
   return date.toLocaleDateString('ja-JP', {
     year: 'numeric',
     month: '2-digit',
@@ -78,7 +78,8 @@ function formatDate(date: Date): string {
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: #f5f5f5;
+  background: var(--app-bg-soft);
+  transition: background 0.3s;
 }
 
 .memo-list-header {
@@ -86,15 +87,17 @@ function formatDate(date: Date): string {
   justify-content: space-between;
   align-items: center;
   padding: 1rem 1.5rem;
-  background: white;
-  border-bottom: 1px solid #e0e0e0;
+  background: var(--app-bg);
+  border-bottom: 1px solid var(--app-border);
+  transition: background 0.3s, border-color 0.3s;
 }
 
 .memo-list-header h2 {
   margin: 0;
   font-size: 1.25rem;
   font-weight: 600;
-  color: #333;
+  color: var(--app-text);
+  transition: color 0.3s;
 }
 
 .btn-create {
@@ -102,7 +105,7 @@ function formatDate(date: Date): string {
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
-  background: #42b883;
+  background: var(--app-accent);
   color: white;
   border: none;
   border-radius: 6px;
@@ -113,7 +116,7 @@ function formatDate(date: Date): string {
 }
 
 .btn-create:hover {
-  background: #359268;
+  background: var(--app-accent-hover);
 }
 
 .btn-create span {
@@ -124,7 +127,8 @@ function formatDate(date: Date): string {
 .empty-state {
   padding: 3rem 1.5rem;
   text-align: center;
-  color: #999;
+  color: var(--app-text-muted);
+  transition: color 0.3s;
 }
 
 .empty-state p {
@@ -142,7 +146,7 @@ function formatDate(date: Date): string {
 }
 
 .memo-item {
-  background: white;
+  background: var(--app-bg);
   padding: 1rem 1.5rem;
   margin-bottom: 0.5rem;
   border-radius: 8px;
@@ -152,12 +156,12 @@ function formatDate(date: Date): string {
 }
 
 .memo-item:hover {
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px var(--app-shadow);
 }
 
 .memo-item.active {
-  border-color: #42b883;
-  background: #f0fdf7;
+  border-color: var(--app-active-border);
+  background: var(--app-active-bg);
 }
 
 .memo-item-header {
@@ -172,31 +176,34 @@ function formatDate(date: Date): string {
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
-  color: #333;
+  color: var(--app-text);
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  transition: color 0.3s;
 }
 
 .memo-category {
   padding: 0.25rem 0.75rem;
-  background: #e3f2fd;
-  color: #1976d2;
+  background: var(--app-category-bg);
+  color: var(--app-category-text);
   border-radius: 12px;
   font-size: 0.75rem;
   font-weight: 500;
   white-space: nowrap;
+  transition: background 0.3s, color 0.3s;
 }
 
 .memo-preview {
   margin: 0 0 0.5rem;
   font-size: 0.875rem;
-  color: #666;
+  color: var(--app-text-secondary);
   line-height: 1.4;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  transition: color 0.3s;
 }
 
 .memo-meta {
@@ -206,6 +213,7 @@ function formatDate(date: Date): string {
 
 .memo-date {
   font-size: 0.75rem;
-  color: #999;
+  color: var(--app-text-muted);
+  transition: color 0.3s;
 }
 </style>

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -1,0 +1,43 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useThemeStore = defineStore('theme', () => {
+  const isDark = ref(false)
+
+  function initTheme() {
+    const saved = localStorage.getItem('theme')
+    if (saved === 'dark' || saved === 'light') {
+      isDark.value = saved === 'dark'
+    } else {
+      // システムの設定に従う
+      isDark.value = window.matchMedia('(prefers-color-scheme: dark)').matches
+    }
+    applyTheme()
+
+    // システムテーマ変更を監視（ユーザーが手動設定していない場合のみ）
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+      if (!localStorage.getItem('theme')) {
+        isDark.value = e.matches
+        applyTheme()
+      }
+    })
+  }
+
+  function toggleTheme() {
+    isDark.value = !isDark.value
+    localStorage.setItem('theme', isDark.value ? 'dark' : 'light')
+    applyTheme()
+  }
+
+  function applyTheme() {
+    if (isDark.value) {
+      document.documentElement.classList.add('dark')
+      document.documentElement.classList.remove('light')
+    } else {
+      document.documentElement.classList.add('light')
+      document.documentElement.classList.remove('dark')
+    }
+  }
+
+  return { isDark, initTheme, toggleTheme }
+})

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -18,7 +18,7 @@ export const useThemeStore = defineStore('theme', () => {
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
       if (!localStorage.getItem('theme')) {
         isDark.value = e.matches
-        applyTheme()
+        applyThemeWithTransition()
       }
     })
   }
@@ -26,7 +26,16 @@ export const useThemeStore = defineStore('theme', () => {
   function toggleTheme() {
     isDark.value = !isDark.value
     localStorage.setItem('theme', isDark.value ? 'dark' : 'light')
+    applyThemeWithTransition()
+  }
+
+  function applyThemeWithTransition() {
+    // 全要素に一時的なトランジションクラスを付与して滑らかに切り替える
+    document.documentElement.classList.add('theme-transitioning')
     applyTheme()
+    setTimeout(() => {
+      document.documentElement.classList.remove('theme-transitioning')
+    }, 400)
   }
 
   function applyTheme() {

--- a/src/views/MemoListView.vue
+++ b/src/views/MemoListView.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="memo-list-view">
     <div class="list-header-bar">
-      <span class="user-email">{{ authStore.currentUser?.email }}</span>
-      <button @click="handleLogout" class="btn-logout">ログアウト</button>
+      <span class="app-title">メモ帳</span>
+      <HamburgerMenu @logout="handleLogout" />
     </div>
     <MemoList
       :memos="memoStore.sortedMemos"
@@ -18,6 +18,7 @@ import { useRouter } from 'vue-router'
 import { useMemoStore } from '@/stores/memo'
 import { useAuthStore } from '@/stores/auth'
 import MemoList from '@/components/MemoList.vue'
+import HamburgerMenu from '@/components/HamburgerMenu.vue'
 
 const router = useRouter()
 const memoStore = useMemoStore()
@@ -54,33 +55,16 @@ async function handleLogout() {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.5rem 1.5rem;
-  background: #f0fdf7;
-  border-bottom: 1px solid #d1fae5;
+  padding: 0.5rem 1rem 0.5rem 1.5rem;
+  background: var(--app-header-bg);
+  border-bottom: 1px solid var(--app-header-border);
+  transition: background 0.3s, border-color 0.3s;
 }
 
-.user-email {
-  font-size: 0.8rem;
-  color: #666;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.btn-logout {
-  padding: 0.35rem 0.85rem;
-  background: transparent;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  font-size: 0.8rem;
-  color: #666;
-  cursor: pointer;
-  transition: all 0.2s;
-  white-space: nowrap;
-}
-
-.btn-logout:hover {
-  border-color: #e53935;
-  color: #e53935;
+.app-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--app-accent);
+  letter-spacing: 0.02em;
 }
 </style>

--- a/src/views/MemoView.vue
+++ b/src/views/MemoView.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="memo-app">
     <div class="memo-sidebar">
+      <div class="sidebar-header">
+        <span class="app-title">メモ帳</span>
+        <HamburgerMenu @logout="handleLogout" />
+      </div>
       <MemoList
         :memos="memoStore.sortedMemos"
         :selected-id="memoStore.selectedMemoId"
@@ -20,11 +24,14 @@
 
 <script setup lang="ts">
 import { onMounted, onUnmounted } from 'vue'
+import { useRouter } from 'vue-router'
 import { useMemoStore } from '@/stores/memo'
 import { useAuthStore } from '@/stores/auth'
 import MemoList from '@/components/MemoList.vue'
 import MemoEditor from '@/components/MemoEditor.vue'
+import HamburgerMenu from '@/components/HamburgerMenu.vue'
 
+const router = useRouter()
 const memoStore = useMemoStore()
 const authStore = useAuthStore()
 
@@ -60,6 +67,11 @@ async function handleDeleteMemo(id: string) {
   if (!authStore.currentUser) return
   await memoStore.deleteMemo(authStore.currentUser.uid, id)
 }
+
+async function handleLogout() {
+  await authStore.logout()
+  router.push({ name: 'login' })
+}
 </script>
 
 <style scoped>
@@ -71,9 +83,28 @@ async function handleDeleteMemo(id: string) {
 
 .memo-sidebar {
   width: 350px;
-  border-right: 1px solid #e0e0e0;
+  border-right: 1px solid var(--app-border);
   display: flex;
   flex-direction: column;
+  transition: border-color 0.3s;
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem 0.5rem 1.5rem;
+  background: var(--app-header-bg);
+  border-bottom: 1px solid var(--app-header-border);
+  transition: background 0.3s, border-color 0.3s;
+  flex-shrink: 0;
+}
+
+.app-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--app-accent);
+  letter-spacing: 0.02em;
 }
 
 .memo-main {
@@ -92,7 +123,7 @@ async function handleDeleteMemo(id: string) {
     width: 100%;
     height: 50vh;
     border-right: none;
-    border-bottom: 1px solid #e0e0e0;
+    border-bottom: 1px solid var(--app-border);
   }
 
   .memo-main {


### PR DESCRIPTION
## 概要

アカウント名とログアウトをハンバーガーメニューにまとめ、ダーク/ライトモード切り替え機能を追加しました。

## 変更内容

### 新規ファイル
- **`src/components/HamburgerMenu.vue`** — ハンバーガーメニューコンポーネント
- **`src/stores/theme.ts`** — テーマ管理 Pinia ストア

### 機能詳細

#### ハンバーガーメニュー
- ヘッダー右端の `☰` ボタンをクリックでドロップダウンメニューを開く
- 開閉時にスムーズなアニメーション（バーが X に変形）
- メニュー外をクリックすると自動的に閉じる

#### メニュー内容
1. **アカウント名** — ユーザーアイコン＋メールアドレスを表示（リンクなし）
2. **ダーク/ライトモード切り替え** — 月/太陽アイコン付きのトグルボタン
3. **ログアウト** — ログアウトアイコン（左横）付きのボタン

#### ダーク/ライトモード
- `localStorage` に設定を保存（ページ再読み込み後も維持）
- 初回アクセス時はシステムの OS 設定に従う
- システム設定が変わった場合も自動追従（手動設定していない場合）
- `base.css` に CSS カスタムプロパティを追加し、全コンポーネントが動的に切り替わる

### 変更ファイル
- `src/App.vue` — テーマ初期化処理を追加
- `src/assets/base.css` — ダーク/ライト両対応の CSS 変数を追加
- `src/components/MemoEditor.vue` — CSS 変数ベースのスタイルに更新
- `src/components/MemoList.vue` — CSS 変数ベースのスタイルに更新
- `src/views/MemoListView.vue` — ヘッダーを HamburgerMenu に置き換え
- `src/views/MemoView.vue` — サイドバーヘッダーに HamburgerMenu を追加

https://claude.ai/code/session_01SCdSNFRz3hE5Sh6n77i6W3

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCdSNFRz3hE5Sh6n77i6W3)_