### PR TITLE
fix: タスクリストを参考にメモリストのレイアウト欠点を改善

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -44,7 +44,6 @@ body {
 }
 
 #app {
-  height: 100vh;
-  overflow: hidden;
+  min-height: 100vh;
 }
 </style>

--- a/src/components/MemoList.vue
+++ b/src/components/MemoList.vue
@@ -79,20 +79,17 @@ function formatDate(date: Date): string {
 .memo-list {
   display: flex;
   flex-direction: column;
-  height: 100%;
   background: var(--app-bg-soft);
   transition: background 0.3s;
 }
 
 .memo-list-body {
-  flex: 1;
   position: relative;
-  overflow: hidden;
-  min-height: 0;
+  padding-bottom: 5rem;
 }
 
 .fab-create {
-  position: absolute;
+  position: fixed;
   bottom: 2rem;
   right: 2rem;
   width: 56px;
@@ -107,7 +104,7 @@ function formatDate(date: Date): string {
   justify-content: center;
   box-shadow: 0 4px 12px rgba(102, 126, 234, 0.45);
   transition: background 0.2s, transform 0.2s, box-shadow 0.2s;
-  z-index: 10;
+  z-index: 20;
 }
 
 .fab-create svg {
@@ -141,10 +138,7 @@ function formatDate(date: Date): string {
 }
 
 .memo-items {
-  height: 100%;
-  overflow-y: auto;
   padding: 0.5rem;
-  padding-bottom: 5rem;
 }
 
 .memo-item {

--- a/src/components/MemoList.vue
+++ b/src/components/MemoList.vue
@@ -93,8 +93,8 @@ function formatDate(date: Date): string {
 
 .fab-create {
   position: absolute;
-  bottom: 1.5rem;
-  right: 1.5rem;
+  bottom: 2rem;
+  right: 2rem;
   width: 56px;
   height: 56px;
   border-radius: 50%;

--- a/src/components/MemoList.vue
+++ b/src/components/MemoList.vue
@@ -77,6 +77,7 @@ function formatDate(date: Date): string {
 
 <style scoped>
 .memo-list {
+  flex: 1;
   display: flex;
   flex-direction: column;
   background: var(--app-bg-soft);

--- a/src/components/MemoList.vue
+++ b/src/components/MemoList.vue
@@ -1,9 +1,5 @@
 <template>
   <div class="memo-list">
-    <div class="memo-list-header">
-      <h2>メモ一覧</h2>
-    </div>
-
     <div class="memo-list-body">
       <div v-if="memos.length === 0" class="empty-state">
         <p>メモがありません</p>
@@ -93,24 +89,6 @@ function formatDate(date: Date): string {
   position: relative;
   overflow: hidden;
   min-height: 0;
-}
-
-.memo-list-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem 1.5rem;
-  background: var(--app-bg);
-  border-bottom: 1px solid var(--app-border);
-  transition: background 0.3s, border-color 0.3s;
-}
-
-.memo-list-header h2 {
-  margin: 0;
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: var(--app-text);
-  transition: color 0.3s;
 }
 
 .fab-create {

--- a/src/views/MemoEditorView.vue
+++ b/src/views/MemoEditorView.vue
@@ -58,13 +58,17 @@ async function handleDeleteMemo(id: string) {
   flex-direction: column;
   height: 100vh;
   overflow: hidden;
-  background: white;
+  background: var(--app-bg);
+  transition: background 0.3s;
+  max-width: 600px;
+  margin: 0 auto;
 }
 
 .editor-header-nav {
   padding: 1rem 1.5rem;
-  border-bottom: 1px solid #e0e0e0;
-  background: white;
+  border-bottom: 1px solid var(--app-border);
+  background: var(--app-bg);
+  transition: background 0.3s, border-color 0.3s;
 }
 
 .btn-back {
@@ -73,19 +77,19 @@ async function handleDeleteMemo(id: string) {
   gap: 0.5rem;
   padding: 0.5rem 1rem;
   background: transparent;
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--app-border);
   border-radius: 6px;
   font-size: 0.9rem;
   font-weight: 500;
   cursor: pointer;
   transition: all 0.2s;
-  color: #666;
+  color: var(--app-text-secondary);
 }
 
 .btn-back:hover {
-  background: #f5f5f5;
-  border-color: #42b883;
-  color: #42b883;
+  background: var(--app-bg-soft);
+  border-color: var(--app-accent);
+  color: var(--app-accent);
 }
 
 .btn-back svg {

--- a/src/views/MemoListView.vue
+++ b/src/views/MemoListView.vue
@@ -47,13 +47,15 @@ async function handleLogout() {
 .memo-list-view {
   display: flex;
   flex-direction: column;
-  height: 100vh;
-  overflow: hidden;
+  min-height: 100vh;
   max-width: 600px;
   margin: 0 auto;
 }
 
 .list-header-bar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -61,6 +63,7 @@ async function handleLogout() {
   background: var(--app-header-bg);
   border-bottom: 1px solid var(--app-header-border);
   transition: background 0.3s, border-color 0.3s;
+  box-shadow: 0 1px 4px var(--app-shadow);
 }
 
 .app-title {

--- a/src/views/MemoListView.vue
+++ b/src/views/MemoListView.vue
@@ -49,6 +49,8 @@ async function handleLogout() {
   flex-direction: column;
   height: 100vh;
   overflow: hidden;
+  max-width: 600px;
+  margin: 0 auto;
 }
 
 .list-header-bar {

--- a/src/views/MemoListView.vue
+++ b/src/views/MemoListView.vue
@@ -50,12 +50,14 @@ async function handleLogout() {
   min-height: 100vh;
   max-width: 600px;
   margin: 0 auto;
+  background: var(--app-bg-soft);
+  transition: background 0.3s;
 }
 
 .list-header-bar {
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 100;
   display: flex;
   align-items: center;
   justify-content: space-between;


### PR DESCRIPTION
## 改善内容

task-list リポジトリのレイアウトを参考に、memo-list の以下の欠点を修正しました。

## 変更点

### 1. ダークモード対応の修正 (`MemoEditorView.vue`)
`MemoEditorView.vue` にハードコードされた色値がダークモードで正しく表示されない問題を修正。

- `background: white` → `var(--app-bg)`
- `border: 1px solid #e0e0e0` → `var(--app-border)`
- `color: #666` → `var(--app-text-secondary)`
- `background: #f5f5f5`（hover時）→ `var(--app-bg-soft)`
- `border-color: #42b883`（hover時）→ `var(--app-accent)`
- 各プロパティに `transition` を追加してテーマ切り替えをスムーズに

### 2. 二重ヘッダーの解消 (`MemoList.vue`)
task-list はヘッダーが「Todoリスト」のみ1つであるのに対し、memo-list は「メモ帳」（アプリヘッダー）と「メモ一覧」（リスト内ヘッダー）の2段構造になっていた。
- `MemoList` コンポーネント内の「メモ一覧」見出しを削除
- 削除により余分な余白とフォントウェイトの重複が解消され、メモ一覧の表示領域が広がる

### 3. `max-width` センタリングの追加 (`MemoListView.vue`, `MemoEditorView.vue`)
task-list が `max-width: 600px; margin: 0 auto` を適用してデスクトップ環境でも読みやすいレイアウトにしているのに倣い、同様の制約を追加。

## テスト計画

- [ ] ライトモードでメモリスト・エディタ画面が正常表示されること
- [ ] ダークモードでエディタの戻るボタン・背景・ボーダーが正しく切り替わること
- [ ] メモリスト画面のヘッダーが「メモ帳」1つのみになっていること
- [ ] デスクトップ環境（幅1200px以上）でコンテンツが中央寄せ（600px幅）で表示されること
- [ ] モバイル環境（幅600px以下）でレイアウトが崩れないこと

---
_Generated by [Claude Code](https://claude.ai/code/session_016a5ovUfPsHfqp1u8cces3N)_