### PR TITLE
ci: 全リポジトリのベストプラクティスを統合してCI/CDを改善

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,11 +1,13 @@
----
 name: Copilot Setup Steps
 
-# このワークフローはCopilot coding agentのビルド環境で実行される
-# スクリーンショット撮影時に日本語フォントが正しく表示されるように設定
-
-'on':
-  workflow_dispatch: {}
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
 
 jobs:
   copilot-setup-steps:
@@ -14,8 +16,10 @@ jobs:
       contents: read
 
     steps:
-      # 日本語フォントのインストール
-      - name: Install Japanese fonts
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: フォントのインストール
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -24,38 +28,41 @@ jobs:
             fonts-ipafont \
             fonts-ipaexfont \
             fonts-takao-gothic \
-            fonts-takao-mincho
-
-          # フォントキャッシュの更新
+            fonts-takao-mincho \
+            fonts-liberation \
+            fonts-dejavu \
+            fonts-ubuntu \
+            fonts-open-sans
+          echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | sudo debconf-set-selections
+          sudo apt-get install -y ttf-mscorefonts-installer
+          sudo mkdir -p /usr/share/fonts/truetype/segoe-ui
+          cd /tmp
+          wget -q https://github.com/mrbvrz/segoe-ui-linux/raw/master/font/segoeui.ttf -O segoeui.ttf
+          wget -q https://github.com/mrbvrz/segoe-ui-linux/raw/master/font/segoeuib.ttf -O segoeuib.ttf
+          wget -q https://github.com/mrbvrz/segoe-ui-linux/raw/master/font/segoeuii.ttf -O segoeuii.ttf
+          wget -q https://github.com/mrbvrz/segoe-ui-linux/raw/master/font/segoeuiz.ttf -O segoeuiz.ttf
+          sudo mv *.ttf /usr/share/fonts/truetype/segoe-ui/
           fc-cache -fv
 
-          # インストールされた日本語フォントの確認
-          echo "=== Installed Japanese fonts ==="
-          fc-list :lang=ja family | sort -u
-
-      # Node.js環境のセットアップ
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-
-      # 依存関係のインストール
-      - name: Checkout repository
-        uses: actions/checkout@v4
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
 
-      # ビルドの実行
-      - name: Build application
-        run: npm run build
+      - name: 型チェック
+        run: npm run type-check
 
-      # 開発サーバーの起動（スクリーンショット撮影用）
-      - name: Start development server
+      - name: ビルド
+        run: npm run build-only
+
+      - name: 開発サーバーの起動
         run: npm run dev &
 
-      # サーバーの起動を待機
-      - name: Wait for server
+      - name: サーバーの起動待機
         run: |
           timeout 60 bash -c \
             'until curl -sf http://localhost:5173 > /dev/null; \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,16 +4,17 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 concurrency:
-  group: gh-pages
+  group: pages
   cancel-in-progress: false
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
 
     steps:
@@ -40,3 +41,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
           keep_files: true
+          exclude_assets: 'pr-*'

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -10,8 +10,8 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: gh-pages
-  cancel-in-progress: false
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
 
 jobs:
   deploy-preview:


### PR DESCRIPTION
## 概要

3リポジトリ（memo-list / task-list / check-list）を横断比較し、各リポジトリのベストプラクティスを統合したCI/CD改善です。

## 変更内容

### `deploy.yml`
| 項目 | 変更前 | 変更後 |
|---|---|---|
| 手動トリガー | なし | `workflow_dispatch` 追加 |
| concurrencyグループ | `gh-pages` | `pages`（pr-previewと分離） |
| PR プレビュー保護 | なし | `exclude_assets: 'pr-*'` 追加（デプロイ時にPRプレビューを削除しない） |

### `pr-preview.yml`
| 項目 | 変更前 | 変更後 |
|---|---|---|
| concurrencyグループ | `gh-pages`（deployと共有・競合リスク） | `pr-preview-${{ github.event.number }}`（PR単位で独立） |
| cancel-in-progress | `false` | `true`（古いプレビュービルドをキャンセル） |

### `copilot-setup-steps.yml`
| 項目 | 変更前 | 変更後 |
|---|---|---|
| トリガー | `workflow_dispatch` のみ | `push/pull_request`（ファイル変更時にも実行可能） |
| ステップ順序 | フォント → Node → **Checkout** → Install | **Checkout** → フォント → Node → Install（正しい順序） |
| フォント | Noto CJK + IPA 系のみ | + Segoe UI / Liberation / DejaVu / Ubuntu（check-listのベストプラクティスを取り込み） |
| 品質チェック | なし | `type-check` ステップ追加、`build-only` で重複型チェック回避 |

## 参考：リポジトリ間の差分サマリー

- **memo-list**: 最も機能が充実しているが concurrency グループに問題あり → 本PRで修正
- **check-list**: PR プレビューの実装が最良のパターン → memo-listに適用済み
- **task-list**: 別PRで大幅改善（デプロイアクション変更・2ジョブ構成・型チェック追加）

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4nvzyQNBsrYuNkerehU7Q)_