### PR TITLE
スクショに合わせて一覧レイアウトを改修

### DIFF
--- a/src/components/HamburgerMenu.vue
+++ b/src/components/HamburgerMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="hamburger-menu" ref="menuRef">
+  <div class="hamburger-menu">
     <!-- ハンバーガーボタン -->
     <button
       class="hamburger-btn"
@@ -17,9 +17,9 @@
       <div v-if="isOpen" class="menu-overlay" @click="closeMenu"></div>
     </Transition>
 
-    <!-- ドロップダウンメニュー -->
-    <Transition name="slide-down">
-      <div v-if="isOpen" class="menu-dropdown">
+    <!-- 左スライドドロワー -->
+    <Transition name="slide-left">
+      <div v-if="isOpen" class="menu-drawer" role="dialog" aria-modal="true">
 
         <!-- アカウント情報 -->
         <div class="menu-account">
@@ -37,7 +37,6 @@
         <!-- テーマ切り替え -->
         <button class="menu-item" @click="handleThemeToggle">
           <span class="menu-item-icon">
-            <!-- ダークモード時: 月アイコン / ライトモード時: 太陽アイコン（現在のモードを表示） -->
             <svg v-if="themeStore.isDark" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
             </svg>
@@ -76,7 +75,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import { useThemeStore } from '@/stores/theme'
 
@@ -88,7 +87,6 @@ const authStore = useAuthStore()
 const themeStore = useThemeStore()
 
 const isOpen = ref(false)
-const menuRef = ref<HTMLElement | null>(null)
 
 function toggleMenu() {
   isOpen.value = !isOpen.value
@@ -106,21 +104,6 @@ function handleLogout() {
   closeMenu()
   emit('logout')
 }
-
-// メニュー外クリックで閉じる
-function handleClickOutside(event: MouseEvent) {
-  if (menuRef.value && !menuRef.value.contains(event.target as Node)) {
-    closeMenu()
-  }
-}
-
-onMounted(() => {
-  document.addEventListener('mousedown', handleClickOutside)
-})
-
-onUnmounted(() => {
-  document.removeEventListener('mousedown', handleClickOutside)
-})
 </script>
 
 <style scoped>
@@ -144,6 +127,7 @@ onUnmounted(() => {
   cursor: pointer;
   padding: 6px;
   transition: background 0.2s;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .hamburger-btn:hover {
@@ -154,13 +138,12 @@ onUnmounted(() => {
   display: block;
   width: 20px;
   height: 2px;
-  background: var(--app-text-secondary);
+  background: var(--app-accent);
   border-radius: 2px;
   transition: transform 0.25s ease, opacity 0.25s ease;
   transform-origin: center;
 }
 
-/* バーのX変形アニメーション */
 .hamburger-btn.open .bar:nth-child(1) {
   transform: translateY(7px) rotate(45deg);
 }
@@ -174,33 +157,37 @@ onUnmounted(() => {
   transform: translateY(-7px) rotate(-45deg);
 }
 
-/* オーバーレイ */
+/* オーバーレイ（背景を暗くする） */
 .menu-overlay {
   position: fixed;
   inset: 0;
-  z-index: 99;
-}
-
-/* ドロップダウンメニュー */
-.menu-dropdown {
-  position: absolute;
-  top: calc(100% + 8px);
-  right: 0;
-  min-width: 240px;
-  background: var(--app-menu-bg);
-  border: 1px solid var(--app-border);
-  border-radius: 10px;
-  box-shadow: 0 8px 24px var(--app-menu-shadow);
-  overflow: hidden;
+  background: rgba(0, 0, 0, 0.4);
   z-index: 200;
 }
 
-/* アカウント情報（非インタラクティブ） */
+/* 左スライドドロワー */
+.menu-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 280px;
+  max-width: 80vw;
+  background: var(--app-menu-bg);
+  border-right: 1px solid var(--app-border);
+  box-shadow: 4px 0 20px var(--app-menu-shadow);
+  z-index: 300;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+/* アカウント情報 */
 .menu-account {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 1rem 1.25rem;
+  padding: 1.25rem 1.25rem;
   cursor: default;
   pointer-events: none;
   user-select: none;
@@ -216,23 +203,20 @@ onUnmounted(() => {
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 180px;
-  text-decoration: none;
-  -webkit-touch-callout: none;
 }
 
 .account-avatar {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
+  width: 40px;
+  height: 40px;
   background: var(--app-header-bg);
   border: 1px solid var(--app-border);
   border-radius: 50%;
   color: var(--app-accent);
   flex-shrink: 0;
 }
-
 
 /* 区切り線 */
 .menu-divider {
@@ -247,15 +231,16 @@ onUnmounted(() => {
   align-items: center;
   gap: 0.75rem;
   width: 100%;
-  padding: 0.75rem 1.25rem;
+  padding: 0.9rem 1.25rem;
   background: transparent;
   border: none;
   cursor: pointer;
-  font-size: 0.875rem;
+  font-size: 0.9rem;
   color: var(--app-text-secondary);
   text-align: left;
   transition: background 0.15s, color 0.15s;
   font-family: inherit;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .menu-item:hover {
@@ -286,10 +271,10 @@ onUnmounted(() => {
   color: var(--app-logout-hover-text);
 }
 
-/* トランジション */
+/* トランジション: オーバーレイ */
 .fade-enter-active,
 .fade-leave-active {
-  transition: opacity 0.2s ease;
+  transition: opacity 0.25s ease;
 }
 
 .fade-enter-from,
@@ -297,21 +282,17 @@ onUnmounted(() => {
   opacity: 0;
 }
 
-.slide-down-enter-active {
-  transition: opacity 0.2s ease, transform 0.2s ease;
+/* トランジション: ドロワー（左からスライド） */
+.slide-left-enter-active {
+  transition: transform 0.28s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
-.slide-down-leave-active {
-  transition: opacity 0.15s ease, transform 0.15s ease;
+.slide-left-leave-active {
+  transition: transform 0.22s cubic-bezier(0.55, 0, 0.55, 0.2);
 }
 
-.slide-down-enter-from {
-  opacity: 0;
-  transform: translateY(-8px);
-}
-
-.slide-down-leave-to {
-  opacity: 0;
-  transform: translateY(-4px);
+.slide-left-enter-from,
+.slide-left-leave-to {
+  transform: translateX(-100%);
 }
 </style>

--- a/src/components/MemoList.vue
+++ b/src/components/MemoList.vue
@@ -1,35 +1,29 @@
 <template>
   <div class="memo-list">
-    <div class="memo-list-body">
-      <div v-if="memos.length === 0" class="empty-state">
-        <p>メモがありません</p>
-        <p class="empty-hint">右下のボタンでメモを追加しましょう</p>
-      </div>
+    <div v-if="memos.length === 0" class="empty-state">
+      <p>メモがありません</p>
+      <p class="empty-hint">右上のボタンでメモを追加しましょう</p>
+    </div>
 
-      <div v-else class="memo-items">
-        <div
-          v-for="memo in memos"
-          :key="memo.id"
-          :class="['memo-item', { active: selectedId === memo.id }]"
-          @click="$emit('select', memo.id)"
-        >
-          <div class="memo-item-header">
+    <div v-else class="memo-items">
+      <div
+        v-for="memo in memos"
+        :key="memo.id"
+        :class="['memo-item', { active: selectedId === memo.id }]"
+        @click="$emit('select', memo.id)"
+      >
+        <div class="memo-item-inner">
+          <span v-if="memo.isPinned" class="pin-icon" aria-label="ピン留め">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M16 12V4h1V2H7v2h1v8l-2 2v2h5.2v6h1.6v-6H18v-2l-2-2z"/>
+            </svg>
+          </span>
+          <div class="memo-content">
             <h3 class="memo-title">{{ memo.title || '無題のメモ' }}</h3>
-            <span v-if="memo.category" class="memo-category">{{ memo.category }}</span>
-          </div>
-          <p class="memo-preview">{{ getPreview(memo.content) }}</p>
-          <div class="memo-meta">
-            <span class="memo-date">{{ formatDate(memo.updatedAt) }}</span>
+            <p class="memo-preview">{{ getPreview(memo.content) }}</p>
           </div>
         </div>
       </div>
-
-      <button @click="$emit('create')" class="fab-create" aria-label="新規作成">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-          <line x1="12" y1="5" x2="12" y2="19" />
-          <line x1="5" y1="12" x2="19" y2="12" />
-        </svg>
-      </button>
     </div>
   </div>
 </template>
@@ -46,32 +40,12 @@ defineProps<Props>()
 
 defineEmits<{
   select: [id: string]
-  create: []
 }>()
 
-function getPreview(content: string, maxLength = 60): string {
+function getPreview(content: string, maxLength = 100): string {
   const stripped = content.replace(/\n/g, ' ').trim()
   if (stripped.length <= maxLength) return stripped
   return stripped.substring(0, maxLength) + '...'
-}
-
-function formatDate(date: Date): string {
-  const now = new Date()
-  const diff = now.getTime() - date.getTime()
-  const minutes = Math.floor(diff / 60000)
-  const hours = Math.floor(diff / 3600000)
-  const days = Math.floor(diff / 86400000)
-
-  if (minutes < 1) return 'たった今'
-  if (minutes < 60) return `${minutes}分前`
-  if (hours < 24) return `${hours}時間前`
-  if (days < 7) return `${days}日前`
-
-  return date.toLocaleDateString('ja-JP', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit'
-  })
 }
 </script>
 
@@ -80,47 +54,8 @@ function formatDate(date: Date): string {
   flex: 1;
   display: flex;
   flex-direction: column;
-  background: var(--app-bg-soft);
+  background: var(--app-bg);
   transition: background 0.3s;
-}
-
-.memo-list-body {
-  position: relative;
-  padding-bottom: 5rem;
-}
-
-.fab-create {
-  position: fixed;
-  bottom: 2rem;
-  right: 2rem;
-  width: 56px;
-  height: 56px;
-  border-radius: 50%;
-  background: var(--app-accent);
-  color: white;
-  border: none;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.45);
-  transition: background 0.2s, transform 0.2s, box-shadow 0.2s;
-  z-index: 20;
-}
-
-.fab-create svg {
-  width: 26px;
-  height: 26px;
-}
-
-.fab-create:hover {
-  background: var(--app-accent-hover);
-  transform: scale(1.08);
-  box-shadow: 0 6px 18px rgba(102, 126, 234, 0.55);
-}
-
-.fab-create:active {
-  transform: scale(0.95);
 }
 
 .empty-state {
@@ -139,78 +74,67 @@ function formatDate(date: Date): string {
 }
 
 .memo-items {
-  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
 }
 
 .memo-item {
   background: var(--app-bg);
-  padding: 1rem 1.5rem;
-  margin-bottom: 0.5rem;
-  border-radius: 8px;
   cursor: pointer;
-  transition: all 0.2s;
-  border: 2px solid transparent;
+  border-bottom: 1px solid var(--app-border);
+  transition: background 0.15s;
+  -webkit-tap-highlight-color: transparent;
 }
 
-.memo-item:hover {
-  box-shadow: 0 2px 8px var(--app-shadow);
+.memo-item:last-child {
+  border-bottom: none;
 }
 
+.memo-item:active,
 .memo-item.active {
-  border-color: var(--app-active-border);
   background: var(--app-active-bg);
 }
 
-.memo-item-header {
+.memo-item-inner {
   display: flex;
-  justify-content: space-between;
   align-items: flex-start;
-  gap: 1rem;
-  margin-bottom: 0.5rem;
+  gap: 0.5rem;
+  padding: 0.85rem 1rem;
+}
+
+.pin-icon {
+  color: #3b82f6;
+  flex-shrink: 0;
+  margin-top: 2px;
+  display: flex;
+  align-items: center;
+}
+
+.memo-content {
+  flex: 1;
+  min-width: 0;
 }
 
 .memo-title {
-  margin: 0;
+  margin: 0 0 0.2rem;
   font-size: 1rem;
   font-weight: 600;
   color: var(--app-text);
-  flex: 1;
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
   transition: color 0.3s;
-}
-
-.memo-category {
-  padding: 0.25rem 0.75rem;
-  background: var(--app-category-bg);
-  color: var(--app-category-text);
-  border-radius: 12px;
-  font-size: 0.75rem;
-  font-weight: 500;
-  white-space: nowrap;
-  transition: background 0.3s, color 0.3s;
 }
 
 .memo-preview {
-  margin: 0 0 0.5rem;
-  font-size: 0.875rem;
+  margin: 0;
+  font-size: 0.82rem;
   color: var(--app-text-secondary);
-  line-height: 1.4;
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  transition: color 0.3s;
-}
-
-.memo-meta {
-  display: flex;
-  justify-content: flex-end;
-}
-
-.memo-date {
-  font-size: 0.75rem;
-  color: var(--app-text-muted);
   transition: color 0.3s;
 }
 </style>

--- a/src/stores/memo.ts
+++ b/src/stores/memo.ts
@@ -26,9 +26,11 @@ export const useMemoStore = defineStore('memo', () => {
   )
 
   const sortedMemos = computed(() =>
-    [...memos.value].sort((a, b) =>
-      b.updatedAt.getTime() - a.updatedAt.getTime()
-    )
+    [...memos.value].sort((a, b) => {
+      if (a.isPinned && !b.isPinned) return -1
+      if (!a.isPinned && b.isPinned) return 1
+      return b.updatedAt.getTime() - a.updatedAt.getTime()
+    })
   )
 
   const categories = computed(() => {
@@ -55,6 +57,7 @@ export const useMemoStore = defineStore('memo', () => {
           title: data.title ?? '',
           content: data.content ?? '',
           category: data.category,
+          isPinned: data.isPinned ?? false,
           createdAt: (data.createdAt as Timestamp).toDate(),
           updatedAt: (data.updatedAt as Timestamp).toDate()
         }

--- a/src/types/memo.ts
+++ b/src/types/memo.ts
@@ -8,6 +8,7 @@ export interface Memo {
   createdAt: Date
   updatedAt: Date
   category?: string
+  isPinned?: boolean
 }
 
 /**

--- a/src/views/MemoListView.vue
+++ b/src/views/MemoListView.vue
@@ -1,19 +1,41 @@
 <template>
   <div class="memo-list-view">
     <div class="list-header-bar">
-      <span class="app-title">メモ帳</span>
       <HamburgerMenu @logout="handleLogout" />
+      <span class="app-title">すべてのノート</span>
+      <button class="compose-btn" @click="handleCreateMemo" aria-label="新規作成">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 20h9"/>
+          <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/>
+        </svg>
+      </button>
     </div>
+
+    <div class="search-bar-wrap">
+      <div class="search-bar">
+        <svg class="search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="11" cy="11" r="8"/>
+          <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+        </svg>
+        <input
+          v-model="searchQuery"
+          type="search"
+          class="search-input"
+          placeholder="メモまたはタグを検索"
+        />
+      </div>
+    </div>
+
     <MemoList
-      :memos="memoStore.sortedMemos"
+      :memos="filteredMemos"
       :selected-id="null"
       @select="handleSelectMemo"
-      @create="handleCreateMemo"
     />
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useMemoStore } from '@/stores/memo'
 import { useAuthStore } from '@/stores/auth'
@@ -23,6 +45,16 @@ import HamburgerMenu from '@/components/HamburgerMenu.vue'
 const router = useRouter()
 const memoStore = useMemoStore()
 const authStore = useAuthStore()
+
+const searchQuery = ref('')
+
+const filteredMemos = computed(() => {
+  const q = searchQuery.value.trim().toLowerCase()
+  if (!q) return memoStore.sortedMemos
+  return memoStore.sortedMemos.filter(m =>
+    m.title.toLowerCase().includes(q) || m.content.toLowerCase().includes(q)
+  )
+})
 
 function handleSelectMemo(id: string) {
   router.push({ name: 'memo-edit', params: { id } })
@@ -50,7 +82,7 @@ async function handleLogout() {
   min-height: 100vh;
   max-width: 600px;
   margin: 0 auto;
-  background: var(--app-bg-soft);
+  background: var(--app-bg);
   transition: background 0.3s;
 }
 
@@ -61,7 +93,7 @@ async function handleLogout() {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.5rem 1rem 0.5rem 1.5rem;
+  padding: 0.5rem 0.75rem;
   background: var(--app-header-bg);
   border-bottom: 1px solid var(--app-header-border);
   transition: background 0.3s, border-color 0.3s;
@@ -70,8 +102,69 @@ async function handleLogout() {
 
 .app-title {
   font-size: 1rem;
-  font-weight: 600;
+  font-weight: 700;
+  color: var(--app-text);
+  letter-spacing: 0.01em;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.compose-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
   color: var(--app-accent);
-  letter-spacing: 0.02em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 6px;
+  padding: 0;
+  transition: background 0.2s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.compose-btn:hover {
+  background: var(--app-menu-hover);
+}
+
+.search-bar-wrap {
+  padding: 0.6rem 0.75rem;
+  background: var(--app-bg);
+  border-bottom: 1px solid var(--app-border);
+}
+
+.search-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--app-bg-soft);
+  border-radius: 10px;
+  padding: 0.45rem 0.75rem;
+}
+
+.search-icon {
+  color: var(--app-text-muted);
+  flex-shrink: 0;
+}
+
+.search-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-size: 0.9rem;
+  color: var(--app-text);
+  outline: none;
+  font-family: inherit;
+}
+
+.search-input::placeholder {
+  color: var(--app-text-muted);
+}
+
+.search-input::-webkit-search-cancel-button {
+  -webkit-appearance: none;
 }
 </style>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- ヘッダーをハンバーガー(左)・「すべてのノート」中央・コンポーズボタン(右)に変更
- 検索バーを追加（タイトル・本文でフィルタリング）
- カードスタイルをフラットリスト（区切り線）に変更してスクショのデザインに統一
- `isPinned` フィールドを追加しピン留めアイコン表示・ピン固定ソートに対応
- プレビューを2行クランプ表示に変更、日付・カテゴリバッジを非表示
- FABを廃止しヘッダーのコンポーズボタンに統合

## Test plan

- [ ] 一覧画面を開き、ヘッダーが「≡ すべてのノート ✏」の構成になっている
- [ ] 検索バーに文字を入力するとタイトル・本文でフィルタリングされる
- [ ] メモが区切り線区切りのフラットリストで表示される
- [ ] `isPinned: true` のメモにピンアイコンが表示され、一覧の上部に固定される
- [ ] コンポーズボタンで新規メモ作成画面に遷移する
- [ ] ダークモード切り替えで色が正しく反映される

https://claude.ai/code/session_01Gb5RstLYvQKBq1ZeUfr8tb
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gb5RstLYvQKBq1ZeUfr8tb)_