### PR TITLE
manifest.webmanifest 404エラーとPWA関連の警告を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="apple-touch-icon" sizes="167x167" href="/icons/apple-touch-icon-167x167.png">
     <link rel="apple-touch-icon" sizes="152x152" href="/icons/apple-touch-icon-152x152.png">
     <link rel="apple-touch-icon" sizes="120x120" href="/icons/apple-touch-icon-120x120.png">
-    <link rel="manifest" href="/manifest.webmanifest">
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="メモリスト">


### PR DESCRIPTION
## Summary

- `index.html`のハードコードされた`<link rel="manifest" href="/manifest.webmanifest">`を削除。VitePWAプラグインがビルド時にbase path（`/memo-list/`）を含む正しいパスで自動挿入するため、GitHub Pagesでの404エラーが解消される
- `<meta name="mobile-web-app-capable" content="yes">`を追加し、非推奨警告を修正

## 修正されたエラー

- `GET https://keigo-hisazumi.github.io/manifest.webmanifest 404 (Not Found)`
- `<meta name="apple-mobile-web-app-capable">` is deprecated 警告

## 未解決（手動対応が必要）

Firebaseコンソールで `keigo-hisazumi.github.io` をOAuth許可ドメインに追加する必要があります：
**Firebase Console → Authentication → Settings → Authorized domains**

https://claude.ai/code/session_015jE1VCn9xg5fY4Q8CaSEZC

---
_Generated by [Claude Code](https://claude.ai/code/session_015jE1VCn9xg5fY4Q8CaSEZC)_