### PR TITLE
Fix: ヘッダーをスクロールに影響を受けないよう修正

### DIFF
--- a/src/views/MemoListView.vue
+++ b/src/views/MemoListView.vue
@@ -79,17 +79,21 @@ async function handleLogout() {
 .memo-list-view {
   display: flex;
   flex-direction: column;
-  height: 100vh;
-  overflow-y: auto;
+  min-height: 100vh;
   max-width: 600px;
   margin: 0 auto;
+  padding-top: 53px;
   background: var(--app-bg);
   transition: background 0.3s;
 }
 
 .list-header-bar {
-  position: sticky;
+  position: fixed;
   top: 0;
+  left: 0;
+  right: 0;
+  max-width: 600px;
+  margin: 0 auto;
   z-index: 100;
   display: flex;
   align-items: center;

--- a/src/views/MemoListView.vue
+++ b/src/views/MemoListView.vue
@@ -79,7 +79,8 @@ async function handleLogout() {
 .memo-list-view {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  height: 100vh;
+  overflow-y: auto;
   max-width: 600px;
   margin: 0 auto;
   background: var(--app-bg);


### PR DESCRIPTION
## 変更内容\n\n- `.memo-list-view` を `height: 100vh; overflow-y: auto` に変更し、明示的なスクロールコンテナとして設定\n- これにより `position: sticky; top: 0` が持つ `.list-header-bar`（ヘッダー）が iOS Safari を含むすべての環境で確実に固定表示される\n\n## 背景\n\n`position: sticky` はスクロールが発生するコンテナの子要素でないと正常に動作しない場合があります。特に iOS Safari では `body` レベルのスクロールと flex コンテナ内の sticky が干渉することがあります。スクロールコンテナを `.memo-list-view` 自身に限定することで問題を解消しました。

---
_Generated by [Claude Code](https://claude.ai/code/session_018PNnHyWKGoSpUPvhvY6KXo)_