### PR TITLE
fix: タイトル入力時に本文がリセットされる不具合を修正

### DIFF
--- a/src/components/MemoEditor.vue
+++ b/src/components/MemoEditor.vue
@@ -74,11 +74,12 @@ const localCategory = ref('')
 const titleRef = ref<HTMLInputElement | null>(null)
 const contentRef = ref<HTMLTextAreaElement | null>(null)
 
-watch(() => props.memo, (newMemo) => {
-  if (newMemo) {
-    localTitle.value = newMemo.title
-    localContent.value = newMemo.content
-    localCategory.value = newMemo.category || ''
+watch(() => props.memo?.id, () => {
+  const memo = props.memo
+  if (memo) {
+    localTitle.value = memo.title
+    localContent.value = memo.content
+    localCategory.value = memo.category || ''
   } else {
     localTitle.value = ''
     localContent.value = ''


### PR DESCRIPTION
## 問題

編集画面でタイトルを入力すると、本文にも同じ内容が反映されてしまう不具合。

## 原因

`MemoEditor.vue` の `watch` が `props.memo` オブジェクト全体を監視していた。

Firestore の `onSnapshot` が発火するたびに `memos.value` が新しい配列に置き換えられるため、`selectedMemo` computed の返すオブジェクト参照が毎回変わる。その結果：

1. タイトル入力 → `handleUpdate` → Firestore に書き込み
2. Firestore がローカルキャッシュから即座に `onSnapshot` を発火
3. `memos.value` 更新 → `selectedMemo` の参照が変わる
4. `watch` が発火して `localContent` が Firestore の値でリセットされる

この race condition により、タイトル入力中に本文の内容が意図せず書き換えられていた。

## 修正

`props.memo` 全体ではなく `props.memo?.id` を監視するよう変更。これにより、別のメモに切り替わったときのみローカル状態をリセットし、同一メモへの Firestore 更新ではリセットされなくなる。

https://claude.ai/code/session_014WY4dWqV7Nzzb2cjUG7mPV

---
_Generated by [Claude Code](https://claude.ai/code/session_014WY4dWqV7Nzzb2cjUG7mPV)_