### PR TITLE
スマホ表示のヘッダー高さ・幅のずれを修正

### DIFF
--- a/src/views/MemoEditorView.vue
+++ b/src/views/MemoEditorView.vue
@@ -160,9 +160,10 @@ async function handleDeleteMemo(id: string) {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.6rem 0.75rem;
+  padding: 0.5rem 0.75rem;
   background: var(--app-bg);
-  transition: background 0.3s;
+  border-bottom: 1px solid var(--app-border);
+  transition: background 0.3s, border-color 0.3s;
   flex-shrink: 0;
 }
 

--- a/src/views/MemoView.vue
+++ b/src/views/MemoView.vue
@@ -447,6 +447,10 @@ async function handleLogout() {
     width: 100%;
   }
 
+  .memo-sidebar {
+    border-right: none;
+  }
+
   .mobile-hidden {
     display: none;
   }


### PR DESCRIPTION
$(cat <<'EOF'
## 概要

- メモ一覧（`MemoListView`）と編集画面（`MemoEditorView`）でスマホ表示時にヘッダーの横幅・高さが揃っていなかった問題を修正

## 原因

| | padding (上下) | border-bottom |
|---|---|---|
| `.list-header-bar` | `0.5rem` | `1px solid` あり |
| `.editor-nav` (修正前) | `0.6rem` | なし |

縦パディングが 0.1rem 異なり、ボーダーの有無も違うため高さが一致しなかった。

## 修正内容

`MemoEditorView.vue` の `.editor-nav` を修正：
- `padding: 0.6rem 0.75rem` → `padding: 0.5rem 0.75rem`
- `border-bottom: 1px solid var(--app-border)` を追加

これにより両ヘッダーの高さが揃う（約53px）。

https://claude.ai/code/session_01AjGYYGT9o5T4iua457fwbD
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjGYYGT9o5T4iua457fwbD)_