### PR TITLE
feat: ゴミ箱機能 — 削除→ゴミ箱移動・復元・完全削除

### DIFF
--- a/src/components/HamburgerMenu.vue
+++ b/src/components/HamburgerMenu.vue
@@ -34,6 +34,22 @@
 
         <div class="menu-divider"></div>
 
+        <!-- すべてのノート -->
+        <button class="menu-item" @click="handleAllNotes">
+          <span class="menu-item-icon">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+              <polyline points="14 2 14 8 20 8"/>
+              <line x1="16" y1="13" x2="8" y2="13"/>
+              <line x1="16" y1="17" x2="8" y2="17"/>
+              <polyline points="10 9 9 9 8 9"/>
+            </svg>
+          </span>
+          <span>すべてのノート</span>
+        </button>
+
+        <div class="menu-divider"></div>
+
         <!-- テーマ切り替え -->
         <button class="menu-item" @click="handleThemeToggle">
           <span class="menu-item-icon">
@@ -113,6 +129,11 @@ function closeMenu() {
 
 function handleThemeToggle() {
   themeStore.toggleTheme()
+}
+
+function handleAllNotes() {
+  closeMenu()
+  router.push({ name: 'memo-list' })
 }
 
 function handleTrash() {

--- a/src/components/HamburgerMenu.vue
+++ b/src/components/HamburgerMenu.vue
@@ -57,6 +57,19 @@
 
         <div class="menu-divider"></div>
 
+        <!-- ゴミ箱 -->
+        <button class="menu-item" @click="handleTrash">
+          <span class="menu-item-icon">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <polyline points="3 6 5 6 21 6"/>
+              <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
+            </svg>
+          </span>
+          <span>ゴミ箱</span>
+        </button>
+
+        <div class="menu-divider"></div>
+
         <!-- ログアウト -->
         <button class="menu-item logout-item" @click="handleLogout">
           <span class="menu-item-icon">
@@ -76,6 +89,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useThemeStore } from '@/stores/theme'
 
@@ -83,6 +97,7 @@ const emit = defineEmits<{
   logout: []
 }>()
 
+const router = useRouter()
 const authStore = useAuthStore()
 const themeStore = useThemeStore()
 
@@ -98,6 +113,11 @@ function closeMenu() {
 
 function handleThemeToggle() {
   themeStore.toggleTheme()
+}
+
+function handleTrash() {
+  closeMenu()
+  router.push({ name: 'trash' })
 }
 
 function handleLogout() {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import MemoView from '../views/MemoView.vue'
 import LoginView from '../views/LoginView.vue'
+import TrashView from '../views/TrashView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -22,6 +23,12 @@ const router = createRouter({
       path: '/memo/:id',
       name: 'memo-edit',
       component: MemoView,
+      meta: { requiresAuth: true }
+    },
+    {
+      path: '/trash',
+      name: 'trash',
+      component: TrashView,
       meta: { requiresAuth: true }
     },
   ],

--- a/src/stores/memo.ts
+++ b/src/stores/memo.ts
@@ -18,6 +18,7 @@ import type { Memo, CreateMemoInput, UpdateMemoInput } from '@/types/memo'
 
 export const useMemoStore = defineStore('memo', () => {
   const memos = ref<Memo[]>([])
+  const trashMemos = ref<Memo[]>([])
   const selectedMemoId = ref<string | null>(null)
   let unsubscribe: Unsubscribe | null = null
 
@@ -30,6 +31,14 @@ export const useMemoStore = defineStore('memo', () => {
       if (a.isPinned && !b.isPinned) return -1
       if (!a.isPinned && b.isPinned) return 1
       return b.updatedAt.getTime() - a.updatedAt.getTime()
+    })
+  )
+
+  const sortedTrashMemos = computed(() =>
+    [...trashMemos.value].sort((a, b) => {
+      const aTime = a.deletedAt?.getTime() ?? 0
+      const bTime = b.deletedAt?.getTime() ?? 0
+      return bTime - aTime
     })
   )
 
@@ -50,18 +59,28 @@ export const useMemoStore = defineStore('memo', () => {
 
     const q = query(memosRef(userId), orderBy('updatedAt', 'desc'))
     unsubscribe = onSnapshot(q, (snapshot) => {
-      memos.value = snapshot.docs.map(d => {
+      const active: Memo[] = []
+      const trash: Memo[] = []
+      snapshot.docs.forEach(d => {
         const data = d.data()
-        return {
+        const memo: Memo = {
           id: d.id,
           title: data.title ?? '',
           content: data.content ?? '',
           category: data.category,
           isPinned: data.isPinned ?? false,
           createdAt: (data.createdAt as Timestamp).toDate(),
-          updatedAt: (data.updatedAt as Timestamp).toDate()
+          updatedAt: (data.updatedAt as Timestamp).toDate(),
+          deletedAt: data.deletedAt ? (data.deletedAt as Timestamp).toDate() : undefined
+        }
+        if (memo.deletedAt) {
+          trash.push(memo)
+        } else {
+          active.push(memo)
         }
       })
+      memos.value = active
+      trashMemos.value = trash
     })
   }
 
@@ -71,6 +90,7 @@ export const useMemoStore = defineStore('memo', () => {
       unsubscribe = null
     }
     memos.value = []
+    trashMemos.value = []
     selectedMemoId.value = null
   }
 
@@ -107,10 +127,27 @@ export const useMemoStore = defineStore('memo', () => {
 
   async function deleteMemo(userId: string, id: string): Promise<void> {
     const ref = doc(db, 'users', userId, 'memos', id)
-    await deleteDoc(ref)
+    await updateDoc(ref, { deletedAt: Timestamp.now() })
     if (selectedMemoId.value === id) {
       selectedMemoId.value = null
     }
+  }
+
+  async function restoreMemo(userId: string, id: string): Promise<void> {
+    const ref = doc(db, 'users', userId, 'memos', id)
+    await updateDoc(ref, { deletedAt: deleteField() })
+  }
+
+  async function permanentlyDeleteMemo(userId: string, id: string): Promise<void> {
+    const ref = doc(db, 'users', userId, 'memos', id)
+    await deleteDoc(ref)
+  }
+
+  async function emptyTrash(userId: string): Promise<void> {
+    const deletions = trashMemos.value.map(memo =>
+      deleteDoc(doc(db, 'users', userId, 'memos', memo.id))
+    )
+    await Promise.all(deletions)
   }
 
   function selectMemo(id: string | null) {
@@ -135,15 +172,20 @@ export const useMemoStore = defineStore('memo', () => {
 
   return {
     memos,
+    trashMemos,
     selectedMemoId,
     selectedMemo,
     sortedMemos,
+    sortedTrashMemos,
     categories,
     subscribeToMemos,
     unsubscribeFromMemos,
     createMemo,
     updateMemo,
     deleteMemo,
+    restoreMemo,
+    permanentlyDeleteMemo,
+    emptyTrash,
     selectMemo,
     getMemoById,
     filterByCategory,

--- a/src/types/memo.ts
+++ b/src/types/memo.ts
@@ -9,6 +9,7 @@ export interface Memo {
   updatedAt: Date
   category?: string
   isPinned?: boolean
+  deletedAt?: Date
 }
 
 /**

--- a/src/views/MemoView.vue
+++ b/src/views/MemoView.vue
@@ -78,7 +78,7 @@
                   <polyline points="3 6 5 6 21 6"/>
                   <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
                 </svg>
-                削除
+                ゴミ箱に移動
               </button>
             </div>
           </div>
@@ -208,10 +208,8 @@ async function handleUpdateMemo(id: string, data: { title?: string; content?: st
 
 async function handleDeleteMemo(id: string) {
   if (!authStore.currentUser) return
-  if (confirm('このメモを削除してもよろしいですか？')) {
-    await memoStore.deleteMemo(authStore.currentUser.uid, id)
-    router.push({ name: 'memo-list' })
-  }
+  await memoStore.deleteMemo(authStore.currentUser.uid, id)
+  router.push({ name: 'memo-list' })
 }
 
 async function handleLogout() {

--- a/src/views/MemoView.vue
+++ b/src/views/MemoView.vue
@@ -409,7 +409,8 @@ async function handleLogout() {
   border-radius: 10px;
   box-shadow: 0 4px 16px var(--app-shadow);
   z-index: 100;
-  min-width: 140px;
+  min-width: 160px;
+  white-space: nowrap;
   overflow: hidden;
 }
 

--- a/src/views/TrashView.vue
+++ b/src/views/TrashView.vue
@@ -1,0 +1,291 @@
+<template>
+  <div class="trash-app">
+    <div class="trash-sidebar">
+      <div class="list-header-bar">
+        <HamburgerMenu @logout="handleLogout" />
+        <span class="app-title">ゴミ箱</span>
+        <div style="width: 36px;"></div>
+      </div>
+
+      <div class="trash-actions-bar">
+        <span class="trash-count">{{ memoStore.sortedTrashMemos.length }} 件</span>
+        <button
+          v-if="memoStore.sortedTrashMemos.length > 0"
+          class="btn-empty-trash"
+          @click="handleEmptyTrash"
+        >
+          ゴミ箱を空にする
+        </button>
+      </div>
+
+      <div class="trash-list">
+        <div v-if="memoStore.sortedTrashMemos.length === 0" class="empty-state">
+          <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" class="empty-icon">
+            <polyline points="3 6 5 6 21 6"/>
+            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
+          </svg>
+          <p>ゴミ箱は空です</p>
+        </div>
+
+        <div
+          v-for="memo in memoStore.sortedTrashMemos"
+          :key="memo.id"
+          class="trash-item"
+        >
+          <div class="trash-item-body">
+            <p class="trash-item-title">{{ memo.title || '無題のメモ' }}</p>
+            <p class="trash-item-preview">{{ memo.content.slice(0, 80) || '内容なし' }}</p>
+            <p class="trash-item-date">削除日時: {{ formatDate(memo.deletedAt!) }}</p>
+          </div>
+          <div class="trash-item-actions">
+            <button class="btn-restore" @click="handleRestore(memo.id)" title="復元">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M1 4v6h6"/>
+                <path d="M3.51 15a9 9 0 1 0 .49-3.5"/>
+              </svg>
+              復元
+            </button>
+            <button class="btn-delete-permanent" @click="handlePermanentDelete(memo.id)" title="完全削除">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <polyline points="3 6 5 6 21 6"/>
+                <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
+              </svg>
+              削除
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+import { useMemoStore } from '@/stores/memo'
+import { useAuthStore } from '@/stores/auth'
+import HamburgerMenu from '@/components/HamburgerMenu.vue'
+
+const router = useRouter()
+const memoStore = useMemoStore()
+const authStore = useAuthStore()
+
+function formatDate(date: Date): string {
+  return date.toLocaleString('ja-JP', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  })
+}
+
+async function handleRestore(id: string) {
+  if (!authStore.currentUser) return
+  await memoStore.restoreMemo(authStore.currentUser.uid, id)
+}
+
+async function handlePermanentDelete(id: string) {
+  if (!authStore.currentUser) return
+  if (confirm('このメモを完全に削除しますか？この操作は元に戻せません。')) {
+    await memoStore.permanentlyDeleteMemo(authStore.currentUser.uid, id)
+  }
+}
+
+async function handleEmptyTrash() {
+  if (!authStore.currentUser) return
+  if (confirm('ゴミ箱を空にしますか？すべてのメモが完全に削除されます。')) {
+    await memoStore.emptyTrash(authStore.currentUser.uid)
+  }
+}
+
+async function handleLogout() {
+  await authStore.logout()
+  router.push({ name: 'login' })
+}
+</script>
+
+<style scoped>
+.trash-app {
+  display: flex;
+  height: 100vh;
+  overflow: hidden;
+  background: var(--app-bg);
+}
+
+.trash-sidebar {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.list-header-bar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  background: var(--app-header-bg);
+  border-bottom: 1px solid var(--app-header-border);
+  flex-shrink: 0;
+  box-shadow: 0 1px 4px var(--app-shadow);
+}
+
+.app-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--app-text);
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.trash-actions-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 0.75rem;
+  background: var(--app-bg);
+  border-bottom: 1px solid var(--app-border);
+  flex-shrink: 0;
+}
+
+.trash-count {
+  font-size: 0.85rem;
+  color: var(--app-text-muted);
+}
+
+.btn-empty-trash {
+  padding: 0.35rem 0.75rem;
+  border: 1px solid var(--app-delete-hover-text);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--app-delete-hover-text);
+  font-size: 0.85rem;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s, color 0.15s;
+}
+
+.btn-empty-trash:hover {
+  background: var(--app-delete-hover-bg);
+}
+
+.trash-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 3rem 1rem;
+  color: var(--app-text-muted);
+  font-size: 0.9rem;
+}
+
+.empty-icon {
+  color: var(--app-text-muted);
+  opacity: 0.5;
+}
+
+.trash-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--app-border);
+  transition: background 0.15s;
+}
+
+.trash-item:hover {
+  background: var(--app-bg-soft);
+}
+
+.trash-item-body {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.trash-item-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--app-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 0.2rem;
+}
+
+.trash-item-preview {
+  font-size: 0.8rem;
+  color: var(--app-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 0.2rem;
+}
+
+.trash-item-date {
+  font-size: 0.75rem;
+  color: var(--app-text-muted);
+}
+
+.trash-item-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-shrink: 0;
+}
+
+.btn-restore,
+.btn-delete-permanent {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.btn-restore {
+  border: 1px solid var(--app-accent);
+  background: transparent;
+  color: var(--app-accent);
+}
+
+.btn-restore:hover {
+  background: var(--app-active-bg);
+}
+
+.btn-delete-permanent {
+  border: 1px solid var(--app-delete-hover-text);
+  background: transparent;
+  color: var(--app-delete-hover-text);
+}
+
+.btn-delete-permanent:hover {
+  background: var(--app-delete-hover-bg);
+}
+
+@media (max-width: 480px) {
+  .trash-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .trash-item-actions {
+    align-self: flex-end;
+  }
+}
+</style>


### PR DESCRIPTION
## 概要

メモ削除をすぐに消去せずゴミ箱に移動する機能を実装しました。

- メモの「削除」操作はゴミ箱への移動（ソフトデリート）に変更
- ゴミ箱画面からの復元が可能
- ゴミ箱画面から個別の完全削除、または「ゴミ箱を空にする」で一括完全削除が可能

## 変更内容

### データモデル
- `Memo` 型に `deletedAt?: Date` フィールドを追加
- Firestoreで `deletedAt` フィールドの有無でアクティブ/ゴミ箱を判別

### ストア (`src/stores/memo.ts`)
- `deleteMemo`: `deleteDoc` → `updateDoc({ deletedAt })` のソフトデリートに変更
- `restoreMemo`: `deletedAt` フィールドを削除して復元
- `permanentlyDeleteMemo`: 完全削除（`deleteDoc`）
- `emptyTrash`: ゴミ箱内全件を一括完全削除
- `trashMemos` / `sortedTrashMemos` computed を追加
- 既存の Firestore リスナーでアクティブ・ゴミ箱を同時に振り分け

### ルーター
- `/trash` ルート（`TrashView`）を追加

### 新規コンポーネント (`src/views/TrashView.vue`)
- ゴミ箱一覧（タイトル・プレビュー・削除日時を表示）
- 各メモに「復元」「削除」ボタン
- 上部に「ゴミ箱を空にする」ボタン（ゴミ箱が空のときは非表示）

### UI 更新
- `HamburgerMenu`: 「ゴミ箱」ナビゲーション項目を追加
- `MemoView`: 削除メニューのラベルを「ゴミ箱に移動」に変更、確認ダイアログを削除（即座にゴミ箱へ）

## テスト計画

- [ ] メモを削除するとゴミ箱に移動し、メモ一覧から消えることを確認
- [ ] ゴミ箱一覧に削除されたメモが表示されることを確認
- [ ] 「復元」でメモ一覧に戻ることを確認
- [ ] 個別「削除」ボタンで完全削除の確認ダイアログ → 完全削除されることを確認
- [ ] 「ゴミ箱を空にする」でゴミ箱内全件が削除されることを確認
- [ ] ハンバーガーメニューから「ゴミ箱」へ遷移できることを確認

https://claude.ai/code/session_01Fv36PQ5MoJ7XEqSBDeMUmw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fv36PQ5MoJ7XEqSBDeMUmw)_