### PR TITLE
ドロワーメニューのテーマ切り替えとログアウトを下部に移動

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="メモリスト">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
     <meta name="format-detection" content="telephone=no,email=no,address=no">
     <meta name="description" content="シンプルで使いやすいメモアプリ">
     <title>メモリスト - Memo List</title>

--- a/src/components/HamburgerMenu.vue
+++ b/src/components/HamburgerMenu.vue
@@ -311,7 +311,11 @@ function handleLogout() {
   color: var(--app-text-secondary);
 }
 
-/* ログアウトボタン */
+/* ログアウトボタン（下部セーフエリア対応） */
+.logout-item {
+  padding-bottom: calc(0.9rem + env(safe-area-inset-bottom));
+}
+
 .logout-item:hover {
   color: var(--app-logout-hover-text);
 }

--- a/src/components/HamburgerMenu.vue
+++ b/src/components/HamburgerMenu.vue
@@ -224,6 +224,7 @@ function handleLogout() {
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 /* アカウント情報 */
@@ -311,11 +312,7 @@ function handleLogout() {
   color: var(--app-text-secondary);
 }
 
-/* ログアウトボタン（下部セーフエリア対応） */
-.logout-item {
-  padding-bottom: calc(0.9rem + env(safe-area-inset-bottom));
-}
-
+/* ログアウトボタン */
 .logout-item:hover {
   color: var(--app-logout-hover-text);
 }

--- a/src/components/HamburgerMenu.vue
+++ b/src/components/HamburgerMenu.vue
@@ -50,6 +50,22 @@
 
         <div class="menu-divider"></div>
 
+        <!-- ゴミ箱 -->
+        <button class="menu-item" @click="handleTrash">
+          <span class="menu-item-icon">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <polyline points="3 6 5 6 21 6"/>
+              <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
+            </svg>
+          </span>
+          <span>ゴミ箱</span>
+        </button>
+
+        <!-- スペーサー -->
+        <div class="menu-spacer"></div>
+
+        <div class="menu-divider"></div>
+
         <!-- テーマ切り替え -->
         <button class="menu-item" @click="handleThemeToggle">
           <span class="menu-item-icon">
@@ -69,19 +85,6 @@
             </svg>
           </span>
           <span>{{ themeStore.isDark ? 'ダークモード' : 'ライトモード' }}</span>
-        </button>
-
-        <div class="menu-divider"></div>
-
-        <!-- ゴミ箱 -->
-        <button class="menu-item" @click="handleTrash">
-          <span class="menu-item-icon">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <polyline points="3 6 5 6 21 6"/>
-              <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
-            </svg>
-          </span>
-          <span>ゴミ箱</span>
         </button>
 
         <div class="menu-divider"></div>
@@ -257,6 +260,11 @@ function handleLogout() {
   border-radius: 50%;
   color: #ffffff;
   flex-shrink: 0;
+}
+
+/* スペーサー */
+.menu-spacer {
+  flex: 1;
 }
 
 /* 区切り線 */


### PR DESCRIPTION
## 変更内容

- ドロワーメニューの「ライトモード/ダークモード」切り替えボタンとログアウトボタンをメニューの下部に移動
- `flex: 1` のスペーサーを使って上部メニュー項目（すべてのノート、ゴミ箱）と下部項目を分離

https://claude.ai/code/session_01SkqT4z7z1782cr6nsbntdA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkqT4z7z1782cr6nsbntdA)_