### PR TITLE
一覧で左スワイプして削除ボタンを表示

### DIFF
--- a/src/components/MemoList.tsx
+++ b/src/components/MemoList.tsx
@@ -98,7 +98,7 @@ function MemoListItem({ memo, active, isOpen, onSelect, onDelete, onOpen }: Item
   }
 
   return (
-    <div className="memo-item-wrapper">
+    <div className={`memo-item-wrapper${isOpen ? ' open' : ''}`}>
       <button
         type="button"
         className="memo-item-delete"
@@ -159,6 +159,13 @@ export default function MemoList({ memos, selectedId, onSelect, onDelete }: Prop
 
   return (
     <div className="memo-list">
+      {openId !== null && (
+        <div
+          className="memo-swipe-overlay"
+          onClick={() => setOpenId(null)}
+          onPointerDown={() => setOpenId(null)}
+        />
+      )}
       <div className="memo-items">
         {memos.map(memo => (
           <MemoListItem
@@ -207,10 +214,21 @@ const styles = `
   flex-direction: column;
 }
 
+.memo-swipe-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: transparent;
+}
+
 .memo-item-wrapper {
   position: relative;
   overflow: hidden;
   border-bottom: 1px solid var(--app-border);
+}
+
+.memo-item-wrapper.open {
+  z-index: 60;
 }
 
 .memo-item-wrapper:last-child {

--- a/src/components/MemoList.tsx
+++ b/src/components/MemoList.tsx
@@ -1,10 +1,16 @@
+import { useRef, useState, type PointerEvent } from 'react'
 import type { Memo } from '@/types/memo'
 
 interface Props {
   memos: Memo[]
   selectedId?: string | null
   onSelect: (id: string) => void
+  onDelete?: (id: string) => void
 }
+
+const DELETE_WIDTH = 88
+const OPEN_THRESHOLD = 40
+const SWIPE_TRIGGER = 8
 
 function getPreview(content: string, maxLength = 100): string {
   const stripped = content.replace(/\n/g, ' ').trim()
@@ -12,7 +18,133 @@ function getPreview(content: string, maxLength = 100): string {
   return stripped.substring(0, maxLength) + '...'
 }
 
-export default function MemoList({ memos, selectedId, onSelect }: Props) {
+interface ItemProps {
+  memo: Memo
+  active: boolean
+  isOpen: boolean
+  onSelect: (id: string) => void
+  onDelete?: (id: string) => void
+  onOpen: (id: string | null) => void
+}
+
+function MemoListItem({ memo, active, isOpen, onSelect, onDelete, onOpen }: ItemProps) {
+  const [offset, setOffset] = useState(0)
+  const startX = useRef(0)
+  const startY = useRef(0)
+  const startOffset = useRef(0)
+  const dragging = useRef(false)
+  const swiped = useRef(false)
+  const decided = useRef(false)
+
+  const translate = isOpen ? -DELETE_WIDTH : -offset
+
+  function handlePointerDown(e: PointerEvent<HTMLDivElement>) {
+    if (e.pointerType === 'mouse') return
+    startX.current = e.clientX
+    startY.current = e.clientY
+    startOffset.current = isOpen ? DELETE_WIDTH : 0
+    dragging.current = true
+    swiped.current = false
+    decided.current = false
+  }
+
+  function handlePointerMove(e: PointerEvent<HTMLDivElement>) {
+    if (!dragging.current) return
+    const dx = e.clientX - startX.current
+    const dy = e.clientY - startY.current
+
+    if (!decided.current) {
+      if (Math.abs(dx) < SWIPE_TRIGGER && Math.abs(dy) < SWIPE_TRIGGER) return
+      // Decide gesture direction: vertical scroll vs horizontal swipe
+      if (Math.abs(dy) > Math.abs(dx)) {
+        dragging.current = false
+        return
+      }
+      decided.current = true
+      swiped.current = true
+      e.currentTarget.setPointerCapture(e.pointerId)
+    }
+
+    let next = startOffset.current - dx
+    if (next < 0) next = 0
+    if (next > DELETE_WIDTH + 40) next = DELETE_WIDTH + 40
+    setOffset(next)
+  }
+
+  function endDrag() {
+    if (!dragging.current && !decided.current) return
+    dragging.current = false
+    if (decided.current) {
+      if (offset > OPEN_THRESHOLD) {
+        setOffset(DELETE_WIDTH)
+        onOpen(memo.id)
+      } else {
+        setOffset(0)
+        if (isOpen) onOpen(null)
+      }
+    }
+  }
+
+  function handleClick() {
+    if (swiped.current) {
+      swiped.current = false
+      return
+    }
+    if (isOpen) {
+      onOpen(null)
+      return
+    }
+    onSelect(memo.id)
+  }
+
+  return (
+    <div className="memo-item-wrapper">
+      <button
+        type="button"
+        className="memo-item-delete"
+        style={{ width: DELETE_WIDTH }}
+        onClick={e => { e.stopPropagation(); onDelete?.(memo.id) }}
+        aria-label="削除"
+      >
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <polyline points="3 6 5 6 21 6" />
+          <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+        </svg>
+        <span>削除</span>
+      </button>
+      <div
+        className={`memo-item${active ? ' active' : ''}`}
+        style={{
+          transform: `translateX(${translate}px)`,
+          transition: dragging.current ? 'none' : 'transform 0.2s ease'
+        }}
+        onClick={handleClick}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+      >
+        <div className="memo-item-inner">
+          {memo.isPinned && (
+            <span className="pin-icon" aria-label="ピン留め">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M16 12V4h1V2H7v2h1v8l-2 2v2h5.2v6h1.6v-6H18v-2l-2-2z" />
+              </svg>
+            </span>
+          )}
+          <div className="memo-content">
+            <h3 className="memo-title">{memo.title || '無題のメモ'}</h3>
+            <p className="memo-preview">{getPreview(memo.content)}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function MemoList({ memos, selectedId, onSelect, onDelete }: Props) {
+  const [openId, setOpenId] = useState<string | null>(null)
+
   if (memos.length === 0) {
     return (
       <div className="memo-list">
@@ -29,25 +161,15 @@ export default function MemoList({ memos, selectedId, onSelect }: Props) {
     <div className="memo-list">
       <div className="memo-items">
         {memos.map(memo => (
-          <div
+          <MemoListItem
             key={memo.id}
-            className={`memo-item${selectedId === memo.id ? ' active' : ''}`}
-            onClick={() => onSelect(memo.id)}
-          >
-            <div className="memo-item-inner">
-              {memo.isPinned && (
-                <span className="pin-icon" aria-label="ピン留め">
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M16 12V4h1V2H7v2h1v8l-2 2v2h5.2v6h1.6v-6H18v-2l-2-2z"/>
-                  </svg>
-                </span>
-              )}
-              <div className="memo-content">
-                <h3 className="memo-title">{memo.title || '無題のメモ'}</h3>
-                <p className="memo-preview">{getPreview(memo.content)}</p>
-              </div>
-            </div>
-          </div>
+            memo={memo}
+            active={selectedId === memo.id}
+            isOpen={openId === memo.id}
+            onSelect={onSelect}
+            onDelete={onDelete}
+            onOpen={setOpenId}
+          />
         ))}
       </div>
       <style>{styles}</style>
@@ -85,16 +207,42 @@ const styles = `
   flex-direction: column;
 }
 
-.memo-item {
-  background: var(--app-bg);
-  cursor: pointer;
+.memo-item-wrapper {
+  position: relative;
+  overflow: hidden;
   border-bottom: 1px solid var(--app-border);
-  transition: background 0.15s;
+}
+
+.memo-item-wrapper:last-child {
+  border-bottom: none;
+}
+
+.memo-item-delete {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.15rem;
+  border: none;
+  background: #e5484d;
+  color: #fff;
+  font-size: 0.78rem;
+  font-family: inherit;
+  cursor: pointer;
   -webkit-tap-highlight-color: transparent;
 }
 
-.memo-item:last-child {
-  border-bottom: none;
+.memo-item {
+  position: relative;
+  background: var(--app-bg);
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: pan-y;
+  will-change: transform;
 }
 
 .memo-item:active,

--- a/src/components/MemoList.tsx
+++ b/src/components/MemoList.tsx
@@ -30,6 +30,7 @@ interface ItemProps {
 
 function MemoListItem({ memo, active, isOpen, suppressClickRef, onSelect, onDelete, onOpen }: ItemProps) {
   const [offset, setOffset] = useState(0)
+  const [isDragging, setIsDragging] = useState(false)
   const startX = useRef(0)
   const startY = useRef(0)
   const startOffset = useRef(0)
@@ -37,7 +38,8 @@ function MemoListItem({ memo, active, isOpen, suppressClickRef, onSelect, onDele
   const swiped = useRef(false)
   const decided = useRef(false)
 
-  const translate = isOpen ? -DELETE_WIDTH : -offset
+  // Resting position is driven solely by isOpen; offset is only used mid-drag.
+  const translate = isDragging ? -offset : (isOpen ? -DELETE_WIDTH : 0)
 
   function handlePointerDown(e: PointerEvent<HTMLDivElement>) {
     if (e.pointerType === 'mouse') return
@@ -63,6 +65,7 @@ function MemoListItem({ memo, active, isOpen, suppressClickRef, onSelect, onDele
       }
       decided.current = true
       swiped.current = true
+      setIsDragging(true)
       e.currentTarget.setPointerCapture(e.pointerId)
     }
 
@@ -73,17 +76,17 @@ function MemoListItem({ memo, active, isOpen, suppressClickRef, onSelect, onDele
   }
 
   function endDrag() {
-    if (!dragging.current && !decided.current) return
+    if (!dragging.current) return
     dragging.current = false
+    setIsDragging(false)
     if (decided.current) {
       if (offset > OPEN_THRESHOLD) {
-        setOffset(DELETE_WIDTH)
         onOpen(memo.id)
-      } else {
-        setOffset(0)
-        if (isOpen) onOpen(null)
+      } else if (isOpen) {
+        onOpen(null)
       }
     }
+    setOffset(0)
   }
 
   function handleClick() {
@@ -122,7 +125,7 @@ function MemoListItem({ memo, active, isOpen, suppressClickRef, onSelect, onDele
         className={`memo-item${active ? ' active' : ''}`}
         style={{
           transform: `translateX(${translate}px)`,
-          transition: dragging.current ? 'none' : 'transform 0.2s ease'
+          transition: isDragging ? 'none' : 'transform 0.2s ease'
         }}
         onClick={handleClick}
         onPointerDown={handlePointerDown}

--- a/src/components/MemoList.tsx
+++ b/src/components/MemoList.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type PointerEvent } from 'react'
+import { useEffect, useRef, useState, type MutableRefObject, type PointerEvent } from 'react'
 import type { Memo } from '@/types/memo'
 
 interface Props {
@@ -22,12 +22,13 @@ interface ItemProps {
   memo: Memo
   active: boolean
   isOpen: boolean
+  suppressClickRef: MutableRefObject<number>
   onSelect: (id: string) => void
   onDelete?: (id: string) => void
   onOpen: (id: string | null) => void
 }
 
-function MemoListItem({ memo, active, isOpen, onSelect, onDelete, onOpen }: ItemProps) {
+function MemoListItem({ memo, active, isOpen, suppressClickRef, onSelect, onDelete, onOpen }: ItemProps) {
   const [offset, setOffset] = useState(0)
   const startX = useRef(0)
   const startY = useRef(0)
@@ -90,6 +91,11 @@ function MemoListItem({ memo, active, isOpen, onSelect, onDelete, onOpen }: Item
       swiped.current = false
       return
     }
+    // A tap that just dismissed an open delete button should not also navigate.
+    if (Date.now() - suppressClickRef.current < 350) {
+      suppressClickRef.current = 0
+      return
+    }
     if (isOpen) {
       onOpen(null)
       return
@@ -98,7 +104,7 @@ function MemoListItem({ memo, active, isOpen, onSelect, onDelete, onOpen }: Item
   }
 
   return (
-    <div className={`memo-item-wrapper${isOpen ? ' open' : ''}`}>
+    <div className="memo-item-wrapper">
       <button
         type="button"
         className="memo-item-delete"
@@ -144,6 +150,25 @@ function MemoListItem({ memo, active, isOpen, onSelect, onDelete, onOpen }: Item
 
 export default function MemoList({ memos, selectedId, onSelect, onDelete }: Props) {
   const [openId, setOpenId] = useState<string | null>(null)
+  const suppressClickRef = useRef(0)
+
+  // Tapping anywhere outside the delete button retracts the revealed button.
+  useEffect(() => {
+    if (openId === null) return
+    function handleDocPointerDown(e: globalThis.PointerEvent) {
+      const target = e.target as HTMLElement | null
+      if (target?.closest('.memo-item-delete')) return
+      suppressClickRef.current = Date.now()
+      setOpenId(null)
+    }
+    document.addEventListener('pointerdown', handleDocPointerDown)
+    return () => document.removeEventListener('pointerdown', handleDocPointerDown)
+  }, [openId])
+
+  function handleDelete(id: string) {
+    setOpenId(null)
+    onDelete?.(id)
+  }
 
   if (memos.length === 0) {
     return (
@@ -159,13 +184,6 @@ export default function MemoList({ memos, selectedId, onSelect, onDelete }: Prop
 
   return (
     <div className="memo-list">
-      {openId !== null && (
-        <div
-          className="memo-swipe-overlay"
-          onClick={() => setOpenId(null)}
-          onPointerDown={() => setOpenId(null)}
-        />
-      )}
       <div className="memo-items">
         {memos.map(memo => (
           <MemoListItem
@@ -173,8 +191,9 @@ export default function MemoList({ memos, selectedId, onSelect, onDelete }: Prop
             memo={memo}
             active={selectedId === memo.id}
             isOpen={openId === memo.id}
+            suppressClickRef={suppressClickRef}
             onSelect={onSelect}
-            onDelete={onDelete}
+            onDelete={handleDelete}
             onOpen={setOpenId}
           />
         ))}
@@ -214,21 +233,10 @@ const styles = `
   flex-direction: column;
 }
 
-.memo-swipe-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 50;
-  background: transparent;
-}
-
 .memo-item-wrapper {
   position: relative;
   overflow: hidden;
   border-bottom: 1px solid var(--app-border);
-}
-
-.memo-item-wrapper.open {
-  z-index: 60;
 }
 
 .memo-item-wrapper:last-child {

--- a/src/views/MemoView.tsx
+++ b/src/views/MemoView.tsx
@@ -63,6 +63,12 @@ export default function MemoView() {
     navigate(`/memo/${memoId}`)
   }
 
+  async function handleDeleteFromList(memoId: string) {
+    if (!currentUser) return
+    await memoStore.deleteMemo(currentUser.uid, memoId)
+    if (id === memoId) navigate('/')
+  }
+
   async function handleUpdateMemo(memoId: string, data: { title?: string; content?: string; category?: string }) {
     if (!currentUser) return
     await memoStore.updateMemo(currentUser.uid, memoId, data)
@@ -121,6 +127,7 @@ export default function MemoView() {
           memos={filteredMemos}
           selectedId={memoStore.selectedMemoId}
           onSelect={handleSelectMemo}
+          onDelete={handleDeleteFromList}
         />
       </div>
 


### PR DESCRIPTION
## 概要

メモ一覧の各項目を左にスワイプすると、削除ボタンが現れるようにしました。削除ボタンをタップするとそのメモをゴミ箱に移動します（既存の削除挙動と同じく `deleteMemo` を利用）。

## 変更内容

- `src/components/MemoList.tsx`
  - 各メモ項目を `MemoListItem` コンポーネントに分離
  - Pointer イベントで左スワイプを検出し、右端に削除ボタン（赤背景・ゴミ箱アイコン）を表示
  - 縦スクロールとの誤判定を防ぐため、横移動が縦移動より大きいときだけスワイプとして扱う
  - 一度に開く削除ボタンは1件のみ（`openId` で管理）。開いている状態で項目をタップすると閉じる
  - スワイプ操作直後の意図しない選択（画面遷移）を抑止
- `src/views/MemoView.tsx`
  - `onDelete` ハンドラを追加し `MemoList` に渡す
  - 削除したメモが編集中だった場合は一覧へ戻る

## 動作確認

- `npm run type-check` ✅
- `npm run lint` ✅
- `npm run build` ✅

https://claude.ai/code/session_014TNYPmiSbUn84sX1rNaHyE

---
_Generated by [Claude Code](https://claude.ai/code/session_014TNYPmiSbUn84sX1rNaHyE)_