### PR TITLE
feat: markdown-editer の良い実装を取り込む

### DIFF
--- a/src/components/HamburgerMenu.tsx
+++ b/src/components/HamburgerMenu.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
 import { useTheme } from '@/contexts/ThemeContext'
+import { useMemo2 } from '@/contexts/MemoContext'
 
 interface Props {
   onLogout: () => void
@@ -12,6 +13,8 @@ export default function HamburgerMenu({ onLogout }: Props) {
   const navigate = useNavigate()
   const { currentUser } = useAuth()
   const { isDark, toggleTheme } = useTheme()
+  // ゴミ箱の件数バッジ（markdown-editer のドロワーから取り込み）
+  const trashCount = useMemo2().sortedTrashMemos.length
 
   function closeMenu() { setIsOpen(false) }
 
@@ -82,6 +85,7 @@ export default function HamburgerMenu({ onLogout }: Props) {
             </svg>
           </span>
           <span>ゴミ箱</span>
+          {trashCount > 0 && <span className="menu-badge">{trashCount}</span>}
         </button>
 
         <div className="menu-spacer"></div>
@@ -295,6 +299,22 @@ const styles = `
 
 .menu-item:hover .menu-item-icon {
   color: var(--app-text-secondary);
+}
+
+.menu-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  margin-left: auto;
+  background: #e5484d;
+  color: #fff;
+  border-radius: 9px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  line-height: 1;
 }
 
 .logout-item:hover {

--- a/src/components/MemoEditor.tsx
+++ b/src/components/MemoEditor.tsx
@@ -4,6 +4,8 @@ import type { Memo } from '@/types/memo'
 interface Props {
   memo: Memo | null
   onUpdate: (id: string, data: { title?: string; content?: string; category?: string }) => void
+  /** 保存待ち（編集中）かどうかが変化したときに呼ばれる */
+  onDirtyChange?: (dirty: boolean) => void
 }
 
 type MemoUpdate = { title?: string; content?: string; category?: string }
@@ -11,21 +13,24 @@ type MemoUpdate = { title?: string; content?: string; category?: string }
 // 入力が落ち着いてから Firestore へ書き込むまでの待機時間（ミリ秒）
 const SAVE_DEBOUNCE_MS = 600
 
-export default function MemoEditor({ memo, onUpdate }: Props) {
+export default function MemoEditor({ memo, onUpdate, onDirtyChange }: Props) {
   const [localTitle, setLocalTitle] = useState('')
   const [localContent, setLocalContent] = useState('')
   const [localCategory, setLocalCategory] = useState('')
   const titleRef = useRef<HTMLInputElement>(null)
   const contentRef = useRef<HTMLTextAreaElement>(null)
 
-  // 最新の onUpdate を参照しつつ、保存待ちの編集内容をデバウンスして書き込む。
-  // キーストロークごとの Firestore 書き込みを抑えつつ自動保存の体験を保つ。
+  // 最新の onUpdate / onDirtyChange を参照しつつ、保存待ちの編集内容を
+  // デバウンスして書き込む。キーストロークごとの Firestore 書き込みを
+  // 抑えつつ自動保存の体験を保つ。
   const onUpdateRef = useRef(onUpdate)
+  const onDirtyChangeRef = useRef(onDirtyChange)
   const pendingRef = useRef<{ id: string; data: MemoUpdate } | null>(null)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     onUpdateRef.current = onUpdate
+    onDirtyChangeRef.current = onDirtyChange
   })
 
   function flush() {
@@ -37,12 +42,14 @@ export default function MemoEditor({ memo, onUpdate }: Props) {
     if (pending) {
       pendingRef.current = null
       onUpdateRef.current(pending.id, pending.data)
+      onDirtyChangeRef.current?.(false)
     }
   }
 
   function scheduleUpdate(id: string, data: MemoUpdate) {
     const prev = pendingRef.current?.id === id ? pendingRef.current.data : {}
     pendingRef.current = { id, data: { ...prev, ...data } }
+    onDirtyChangeRef.current?.(true)
     if (timerRef.current) clearTimeout(timerRef.current)
     timerRef.current = setTimeout(flush, SAVE_DEBOUNCE_MS)
   }
@@ -50,6 +57,7 @@ export default function MemoEditor({ memo, onUpdate }: Props) {
   useEffect(() => {
     // メモ切り替え前に、保存待ちの編集内容を確定させる
     flush()
+    onDirtyChangeRef.current?.(false)
     if (memo) {
       setLocalTitle(memo.title)
       setLocalContent(memo.content)

--- a/src/components/MemoEditor.tsx
+++ b/src/components/MemoEditor.tsx
@@ -6,6 +6,11 @@ interface Props {
   onUpdate: (id: string, data: { title?: string; content?: string; category?: string }) => void
 }
 
+type MemoUpdate = { title?: string; content?: string; category?: string }
+
+// 入力が落ち着いてから Firestore へ書き込むまでの待機時間（ミリ秒）
+const SAVE_DEBOUNCE_MS = 600
+
 export default function MemoEditor({ memo, onUpdate }: Props) {
   const [localTitle, setLocalTitle] = useState('')
   const [localContent, setLocalContent] = useState('')
@@ -13,7 +18,38 @@ export default function MemoEditor({ memo, onUpdate }: Props) {
   const titleRef = useRef<HTMLInputElement>(null)
   const contentRef = useRef<HTMLTextAreaElement>(null)
 
+  // 最新の onUpdate を参照しつつ、保存待ちの編集内容をデバウンスして書き込む。
+  // キーストロークごとの Firestore 書き込みを抑えつつ自動保存の体験を保つ。
+  const onUpdateRef = useRef(onUpdate)
+  const pendingRef = useRef<{ id: string; data: MemoUpdate } | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
   useEffect(() => {
+    onUpdateRef.current = onUpdate
+  })
+
+  function flush() {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    const pending = pendingRef.current
+    if (pending) {
+      pendingRef.current = null
+      onUpdateRef.current(pending.id, pending.data)
+    }
+  }
+
+  function scheduleUpdate(id: string, data: MemoUpdate) {
+    const prev = pendingRef.current?.id === id ? pendingRef.current.data : {}
+    pendingRef.current = { id, data: { ...prev, ...data } }
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(flush, SAVE_DEBOUNCE_MS)
+  }
+
+  useEffect(() => {
+    // メモ切り替え前に、保存待ちの編集内容を確定させる
+    flush()
     if (memo) {
       setLocalTitle(memo.title)
       setLocalContent(memo.content)
@@ -24,6 +60,9 @@ export default function MemoEditor({ memo, onUpdate }: Props) {
       setLocalCategory('')
     }
   }, [memo?.id])
+
+  // アンマウント時に保存待ちの編集内容を確定させる
+  useEffect(() => () => flush(), [])
 
   function focusContent() {
     setTimeout(() => contentRef.current?.focus(), 0)
@@ -73,7 +112,7 @@ export default function MemoEditor({ memo, onUpdate }: Props) {
           onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); focusContent() } }}
           onChange={e => {
             setLocalTitle(e.target.value)
-            onUpdate(memo.id, { title: e.target.value })
+            scheduleUpdate(memo.id, { title: e.target.value })
           }}
         />
         <textarea
@@ -84,7 +123,7 @@ export default function MemoEditor({ memo, onUpdate }: Props) {
           autoComplete="off"
           onChange={e => {
             setLocalContent(e.target.value)
-            onUpdate(memo.id, { content: e.target.value })
+            scheduleUpdate(memo.id, { content: e.target.value })
           }}
           onKeyDown={handleContentKeydown}
         />
@@ -103,7 +142,7 @@ export default function MemoEditor({ memo, onUpdate }: Props) {
             placeholder="タグを追加..."
             onChange={e => {
               setLocalCategory(e.target.value)
-              onUpdate(memo.id, { category: e.target.value || undefined })
+              scheduleUpdate(memo.id, { category: e.target.value || undefined })
             }}
           />
         </div>

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState, useEffect, type ReactNode } from 'react'
+import { resolveInitialTheme, applyThemeWithTransition } from '@/theme'
 
 interface ThemeContextValue {
   isDark: boolean
@@ -8,19 +9,11 @@ interface ThemeContextValue {
 const ThemeContext = createContext<ThemeContextValue | null>(null)
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [isDark, setIsDark] = useState(false)
+  // テーマは描画前に main.tsx で適用済みのため、初期値は同じ解決ロジックから取得する。
+  // これにより初期描画時のちらつき（FOUC）を防ぐ。
+  const [isDark, setIsDark] = useState(resolveInitialTheme)
 
   useEffect(() => {
-    const saved = localStorage.getItem('theme')
-    let dark: boolean
-    if (saved === 'dark' || saved === 'light') {
-      dark = saved === 'dark'
-    } else {
-      dark = window.matchMedia('(prefers-color-scheme: dark)').matches
-    }
-    setIsDark(dark)
-    applyTheme(dark)
-
     const mq = window.matchMedia('(prefers-color-scheme: dark)')
     function onSystemChange(e: MediaQueryListEvent) {
       if (!localStorage.getItem('theme')) {
@@ -31,24 +24,6 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     mq.addEventListener('change', onSystemChange)
     return () => mq.removeEventListener('change', onSystemChange)
   }, [])
-
-  function applyTheme(dark: boolean) {
-    if (dark) {
-      document.documentElement.classList.add('dark')
-      document.documentElement.classList.remove('light')
-    } else {
-      document.documentElement.classList.add('light')
-      document.documentElement.classList.remove('dark')
-    }
-  }
-
-  function applyThemeWithTransition(dark: boolean) {
-    document.documentElement.classList.add('theme-transitioning')
-    applyTheme(dark)
-    setTimeout(() => {
-      document.documentElement.classList.remove('theme-transitioning')
-    }, 400)
-  }
 
   function toggleTheme() {
     setIsDark(prev => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,10 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
 import { registerSW } from 'virtual:pwa-register'
+import { resolveInitialTheme, applyTheme } from './theme'
+
+// React の描画前にテーマを適用し、初期描画時のちらつき（FOUC）を防ぐ
+applyTheme(resolveInitialTheme())
 
 registerSW({ immediate: true })
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,35 @@
+/**
+ * テーマ（ライト/ダーク）の解決と適用を担うユーティリティ。
+ *
+ * React の描画前に同期的にテーマを適用できるよう、ThemeContext から
+ * ロジックを切り出している。これにより初期描画時のちらつき（FOUC）を防ぐ。
+ */
+
+/** localStorage と OS 設定から初期テーマ（ダークかどうか）を解決する */
+export function resolveInitialTheme(): boolean {
+  const saved = localStorage.getItem('theme')
+  if (saved === 'dark' || saved === 'light') {
+    return saved === 'dark'
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+}
+
+/** html 要素に light/dark クラスを適用する */
+export function applyTheme(isDark: boolean): void {
+  if (isDark) {
+    document.documentElement.classList.add('dark')
+    document.documentElement.classList.remove('light')
+  } else {
+    document.documentElement.classList.add('light')
+    document.documentElement.classList.remove('dark')
+  }
+}
+
+/** トランジション付きでテーマを適用する（ユーザー操作時に使用） */
+export function applyThemeWithTransition(isDark: boolean): void {
+  document.documentElement.classList.add('theme-transitioning')
+  applyTheme(isDark)
+  setTimeout(() => {
+    document.documentElement.classList.remove('theme-transitioning')
+  }, 400)
+}

--- a/src/views/MemoView.tsx
+++ b/src/views/MemoView.tsx
@@ -25,6 +25,7 @@ export default function MemoView() {
   const [searchQuery, setSearchQuery] = useState('')
   const [showMenu, setShowMenu] = useState(false)
   const [showInfo, setShowInfo] = useState(false)
+  const [isDirty, setIsDirty] = useState(false)
   const [windowWidth, setWindowWidth] = useState(window.innerWidth)
 
   const isMobile = windowWidth < 768
@@ -146,6 +147,11 @@ export default function MemoView() {
           )}
 
           <div className="nav-actions">
+            {memoStore.selectedMemo && (
+              isDirty
+                ? <span className="editing-label">編集中</span>
+                : <span className="saved-label">保存済み</span>
+            )}
             <div className="nav-icon-wrap">
               <button
                 className="nav-icon-btn"
@@ -206,6 +212,7 @@ export default function MemoView() {
         <MemoEditor
           memo={memoStore.selectedMemo}
           onUpdate={handleUpdateMemo}
+          onDirtyChange={setIsDirty}
         />
       </div>
 
@@ -341,6 +348,18 @@ const styles = `
   display: flex;
   align-items: center;
   gap: 0.1rem;
+}
+
+.saved-label {
+  font-size: 0.8rem;
+  color: #10b981;
+  margin-right: 0.3rem;
+}
+
+.editing-label {
+  font-size: 0.8rem;
+  color: #f59e0b;
+  margin-right: 0.3rem;
 }
 
 .nav-icon-wrap {


### PR DESCRIPTION
## 概要

姉妹リポジトリ `markdown-editer` の実装と比較し、優れている点を本リポジトリへ取り込みました。（双方向の取り込みで、`markdown-editer` 側には本リポジトリの良い点を取り込む PR を別途作成しています）

## 取り込んだ内容

### 1. テーマ初期化のちらつき（FOUC）防止
`markdown-editer` は React の描画前にテーマを同期適用することで初期描画のちらつきを防いでいます。本リポジトリは `useEffect` 内で適用していたため、初回読み込み時に一瞬ライトテーマが表示される問題がありました。

- テーマ適用ロジックを `src/theme.ts` に切り出し
- `main.tsx` で `createRoot` の前に `applyTheme(resolveInitialTheme())` を呼び、描画前にテーマを適用
- `ThemeContext` は同じ解決ロジックで初期 state を取得（OS 設定変更の購読のみ `useEffect` に残す）

### 2. メモ編集保存のデバウンス化
従来はキーストロークごとに Firestore へ書き込んでおり、書き込み回数が過剰でした。`markdown-editer` の dirty 管理による効率的な保存の考え方を取り入れ、自動保存の体験を保ちつつ書き込みを抑制しました。

- 入力が落ち着いてから（600ms）まとめて書き込むデバウンス処理を `MemoEditor` に実装
- **メモ切り替え時** と **アンマウント時** には保存待ちの内容を必ず確定（flush）させ、編集内容の取りこぼしを防止
- ローカル state は即時更新のため、入力体験（応答性）は変わりません

## 確認

- `npm run type-check` ✅
- `npm run lint` ✅
- `npm run build` ✅

https://claude.ai/code/session_01ViXEEKThFFiCEgEzWi8paf

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViXEEKThFFiCEgEzWi8paf)_