### PR TITLE
fix: スクロールバーの枠線・背景をライト／ダークモード両方で非表示にする

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -171,6 +171,36 @@
   --app-logout-hover-text: #e53935;
 }
 
+/* スクロールバー：両モードで枠線・背景なし、サムのみ薄く表示 */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(128, 128, 128, 0.3) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+  border: none;
+}
+
+*::-webkit-scrollbar-thumb {
+  background: rgba(128, 128, 128, 0.3);
+  border-radius: 3px;
+  border: none;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background: rgba(128, 128, 128, 0.5);
+}
+
+*::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
 *,
 *::before,
 *::after {


### PR DESCRIPTION
## 変更内容

PC 版でスクロールバーがライト・ダーク両モードに対応していない問題を修正します。

### 修正内容

`src/assets/base.css` にスクロールバー向けのスタイルを追加しました。

- `::-webkit-scrollbar-track`（Chromium 系）と `scrollbar-color`（Firefox）の背景を `transparent` に設定し、枠線・背景色を完全に除去
- サム（つまみ部分）は `rgba(128, 128, 128, 0.3)` の薄いグレーで統一し、ライト・ダーク両モードで自然に馴染む見た目に
- ホバー時はサムをわずかに濃く表示してインタラクティブ性を維持

### 対象ブラウザ

| ブラウザ | 対応プロパティ |
|--------|-------------|
| Chrome / Edge / Safari | `::-webkit-scrollbar-*` |
| Firefox | `scrollbar-width` / `scrollbar-color` |

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4JftLfKiKJkZPVHBuKVhQ)_