### PR TITLE
fix: ヘッダーがスクロールに追従しないように修正

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -201,6 +201,17 @@
   background: transparent;
 }
 
+/* ページ全体のスクロールを抑止し、ヘッダーが固定されるようにする。
+   スクロールは各エリア内部（一覧・エディタ）にのみ発生させる。 */
+html {
+  height: 100%;
+  overflow: hidden;
+}
+
+#app {
+  height: 100%;
+}
+
 *,
 *::before,
 *::after {
@@ -224,7 +235,8 @@ html.theme-transitioning *::after {
 }
 
 body {
-  min-height: 100vh;
+  height: 100%;
+  overflow: hidden;
   color: var(--color-text);
   background: var(--color-background);
   transition:

--- a/src/components/MemoList.tsx
+++ b/src/components/MemoList.tsx
@@ -214,6 +214,9 @@ const styles = `
   background: var(--app-bg);
   transition: background 0.3s;
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-y: contain;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 .empty-state {

--- a/src/views/MemoView.tsx
+++ b/src/views/MemoView.tsx
@@ -225,6 +225,7 @@ const styles = `
 .memo-app {
   display: flex;
   height: 100vh;
+  height: 100svh;
   overflow: hidden;
   background: var(--app-bg);
 }

--- a/src/views/TrashView.tsx
+++ b/src/views/TrashView.tsx
@@ -107,6 +107,7 @@ const styles = `
 .trash-app {
   display: flex;
   height: 100vh;
+  height: 100svh;
   overflow: hidden;
   background: var(--app-bg);
 }

--- a/src/views/TrashView.tsx
+++ b/src/views/TrashView.tsx
@@ -174,7 +174,9 @@ const styles = `
 .trash-list {
   flex: 1;
   overflow-y: auto;
-  padding: 0.5rem 0;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-y: contain;
+  padding: 0.5rem 0 calc(0.5rem + env(safe-area-inset-bottom, 0px));
 }
 
 .empty-state {


### PR DESCRIPTION
## 概要

memo-list でスクロール時にヘッダー（一覧ヘッダー・エディタナビ）が一緒に動いてしまうことがある問題を、markdown-editer の実装を参考に修正しました。

## 原因

markdown-editer では `base.css` で `html` / `body` / `#app` の高さを固定し、ページ全体の `overflow: hidden` を指定することで、スクロールを各エリア内部にのみ限定していました。

一方 memo-list ではこれらの指定がなく、`body { min-height: 100vh; }` のみだったため、`.memo-app` を `height: 100vh; overflow: hidden` にしていても、ページ（document）自体がスクロール可能な状態でした。特にモバイルではブラウザのツールバー表示で表示領域が変化し `100vh` がはみ出すため、ヘッダーを含む画面全体がスクロールしてしまいます。

## 変更内容

- `src/assets/base.css`
  - `html { height: 100%; overflow: hidden; }` と `#app { height: 100%; }` を追加
  - `body` を `min-height: 100vh` から `height: 100%; overflow: hidden` に変更
- `src/views/MemoView.tsx` / `src/views/TrashView.tsx`
  - `.memo-app` / `.trash-app` に `height: 100svh` を追加し、モバイルのツールバー表示時の高さも正しく扱えるように

これにより、スクロールは一覧・エディタなど各エリア内部（`flex: 1; overflow-y: auto`）にのみ発生し、ヘッダーはスクロールの影響を受けず固定されます。

## 確認

- `npm run build` が成功することを確認済み

https://claude.ai/code/session_011VZTPVFBTRCxiPi6t1zz2U

---
_Generated by [Claude Code](https://claude.ai/code/session_011VZTPVFBTRCxiPi6t1zz2U)_