### PR TITLE
fix: ゴミ箱の長いタイトル・本文を省略表示し横スクロールを防止

### DIFF
--- a/src/views/TrashView.tsx
+++ b/src/views/TrashView.tsx
@@ -286,6 +286,10 @@ const styles = `
     align-items: flex-start;
   }
 
+  .trash-item-body {
+    width: 100%;
+  }
+
   .trash-item-actions {
     align-self: flex-end;
   }


### PR DESCRIPTION
## 概要

ゴミ箱でタイトルや本文が長い場合、折り返さずに横スクロールできてしまう不具合を修正しました。`…`（ellipsis）で省略表示され、横スクロールが発生しないようになります。

## 原因

タイトル・本文には既に `white-space: nowrap; overflow: hidden; text-overflow: ellipsis;` が設定されていましたが、スマホ幅（`@media (max-width: 480px)`）で `.trash-item` が `flex-direction: column` かつ `align-items: flex-start` になると、`.trash-item-body` がコンテンツ幅まで収縮してしまい、長いテキストに合わせて幅が広がっていました。

その結果、本文が画面幅を超え、`.trash-list`（`overflow-y: auto` により `overflow-x` が `auto` に算出される）で横スクロールが発生していました。本文が広がったことで ellipsis も効かなくなっていました。

## 修正内容

- スマホ幅の縦並びレイアウト時に `.trash-item-body` の幅を `100%` に固定し、本文領域がコンテンツ幅に収縮しないようにしました。これにより ellipsis が正しく機能し、横スクロールが発生しなくなります。

## 確認

- `tsc --noEmit` による型チェックが通ることを確認済み。

https://claude.ai/code/session_013pB98DrtxgyqBE5BZ23pep

---
_Generated by [Claude Code](https://claude.ai/code/session_013pB98DrtxgyqBE5BZ23pep)_