### PR TITLE
タイトル入力でEnter押下時に本文へフォーカスが移動しないよう修正

### DIFF
--- a/src/components/MemoEditor.tsx
+++ b/src/components/MemoEditor.tsx
@@ -72,10 +72,6 @@ export default function MemoEditor({ memo, onUpdate, onDirtyChange }: Props) {
   // アンマウント時に保存待ちの編集内容を確定させる
   useEffect(() => () => flush(), [])
 
-  function focusContent() {
-    setTimeout(() => contentRef.current?.focus(), 0)
-  }
-
   function handleContentKeydown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     if (e.key === 'Backspace') {
       const textarea = e.currentTarget
@@ -117,7 +113,7 @@ export default function MemoEditor({ memo, onUpdate, onDirtyChange }: Props) {
           className="title-input"
           placeholder="タイトル"
           autoComplete="off"
-          onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); focusContent() } }}
+          onKeyDown={e => { if (e.key === 'Enter') e.preventDefault() }}
           onChange={e => {
             setLocalTitle(e.target.value)
             scheduleUpdate(memo.id, { title: e.target.value })


### PR DESCRIPTION
## 概要

PC版でタイトル入力後にEnterキーを押すと本文（textarea）へフォーカスが移動していた挙動を、移動しないように変更しました。

## 変更内容

- `src/components/MemoEditor.tsx` のタイトル入力の `onKeyDown` ハンドラから、本文へフォーカスを移す `focusContent()` 呼び出しを削除しました。
- Enterキーによる既定動作の抑止（`e.preventDefault()`）は残しているため、Enter押下でフォーカスは移動せず、その場にとどまります。
- 未使用となった `focusContent` 関数を削除しました。

なお、本文（textarea）先頭でBackspaceを押すとタイトルへ戻る挙動はそのまま維持しています。

https://claude.ai/code/session_01WJP9qHcndLdYz2w9kfdt5v

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJP9qHcndLdYz2w9kfdt5v)_