### PR TITLE
PRプレビューで本番Service Workerが横取りし本番画面が表示される問題を修正

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Build with PR-specific base path
         env:
           VITE_BASE_PATH: /memo-list/pr-${{ github.event.number }}/
+          # プレビューでは自己破棄する SW を生成し、本番 SW との競合や
+          # プレビュー同士のキャッシュ混在を防ぐ
+          VITE_DISABLE_PWA: 'true'
         run: npm run build
 
       - name: Deploy PR preview to gh-pages

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,11 +6,19 @@ import { VitePWA } from 'vite-plugin-pwa'
 
 const base = process.env.VITE_BASE_PATH || (process.env.NODE_ENV === 'production' ? '/memo-list/' : '/')
 
+// PR プレビューはすべて同一オリジン（/memo-list/ 配下）に配信されるため、
+// Service Worker を有効にすると本番用 SW（スコープ /memo-list/）がプレビューの
+// ナビゲーションを横取りし、本番の画面が表示されてしまう。プレビュービルドでは
+// 自己破棄する SW を生成して登録済み SW・キャッシュを掃除し、本番 SW 側では
+// プレビューパスをナビゲーションフォールバックの対象外にすることで競合を防ぐ。
+const disablePWA = process.env.VITE_DISABLE_PWA === 'true'
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
     react(),
     VitePWA({
+      selfDestroying: disablePWA,
       registerType: 'autoUpdate',
       base,
       includeAssets: ['favicon.ico', 'icon.svg', 'apple-touch-icon.png', 'icons/*.png'],
@@ -45,6 +53,9 @@ export default defineConfig({
       },
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+        // 本番 SW（スコープ /memo-list/）が PR プレビュー（/memo-list/pr-N/）への
+        // ナビゲーションを本番のアプリシェルで肩代わりしないようにする。
+        navigateFallbackDenylist: [/^\/memo-list\/pr-\d+\//],
         runtimeCaching: [
           {
             urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,


### PR DESCRIPTION
## 概要

PRプレビューURL（例: `https://keigo-hisazumi.github.io/memo-list/pr-47/`）を開くと、PR内容ではなく**本番サイトの画面が表示される**問題を修正します。

## 原因

PRプレビューと本番サイトはすべて同一オリジン `keigo-hisazumi.github.io` の `/memo-list/` 配下に配信されています。本番サイトの Service Worker はスコープ `/memo-list/` で登録されており、このスコープには `/memo-list/pr-N/`（プレビュー）も含まれます。

そのため、過去に本番サイトを開いてSWがインストールされているブラウザでは、本番SWがプレビューへのナビゲーションを横取りし、ナビゲーションフォールバックで**本番のアプリシェル（index.html）をキャッシュから返してしまう**ため、プレビューではなく本番画面が表示されていました。

## 変更内容

`vite.config.ts` と `.github/workflows/pr-preview.yml`:

1. **本番SW**: `workbox.navigateFallbackDenylist` に `/^\/memo-list\/pr-\d+\//` を追加。本番SWがプレビューパスへのナビゲーションをアプリシェルで肩代わりせず、ネットワーク（=正しいプレビュー）へ通すようにする。
2. **プレビュービルド**: 環境変数 `VITE_DISABLE_PWA=true` のとき `VitePWA({ selfDestroying: true })` とし、自己破棄するSWを生成。プレビュー自身がSWを登録して競合・キャッシュ混在を起こすのを防ぐ。

## 動作確認

- プレビュービルド（`VITE_BASE_PATH=/memo-list/pr-47/ VITE_DISABLE_PWA=true`）: ビルド成功、生成された `sw.js` に自己破棄処理（`registration.unregister`）を確認。
- 本番ビルド（`NODE_ENV=production`）: ビルド成功、生成された `sw.js` に denylist（`memo-list\/pr-`）を確認。

## 補足

本番SWの修正は、このPRが `main` にマージされ本番デプロイ（`registerType: 'autoUpdate'`）でSWが更新されてから有効になります。既に本番SWがキャッシュされているブラウザでは、本番再デプロイ後の再訪時にSWが自動更新され、以降プレビューが正しく表示されるようになります。

なお本PRは、別途進行中の「タイトル入力でEnter押下時に本文へフォーカス移動しない修正」（#47）とは独立した、プレビュー環境インフラの修正です。

https://claude.ai/code/session_01WJP9qHcndLdYz2w9kfdt5v

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJP9qHcndLdYz2w9kfdt5v)_