### PR TITLE
本番デプロイがPRプレビューを消す問題を修正（gh-pagesデプロイの直列化）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,8 +9,11 @@ on:
 permissions:
   contents: write
 
+# 本番デプロイと PR プレビューデプロイは同じ gh-pages ブランチへ force-push する。
+# 別々の concurrency group だと同時実行で push が競合し、開設中 PR の
+# pr-* プレビューが消える（keep_files も救えない）。共通 group で直列化する。
 concurrency:
-  group: pages
+  group: gh-pages-deploy
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -9,9 +9,11 @@ permissions:
   contents: write
   pull-requests: write
 
+# 本番デプロイ（deploy.yml）と同じ group で直列化し、gh-pages への
+# 同時 push による競合（pr-* プレビューの消失）を防ぐ。
 concurrency:
-  group: pr-preview-${{ github.event.number }}
-  cancel-in-progress: true
+  group: gh-pages-deploy
+  cancel-in-progress: false
 
 jobs:
   deploy-preview:


### PR DESCRIPTION
## 概要

`main` へのマージ（本番デプロイ）が走るたびに、**開設中のPRプレビュー（`/memo-list/pr-N/`）が gh-pages から消えて404になる**問題を根本修正します。

## 原因

本番デプロイ（`deploy.yml`）とPRプレビューデプロイ（`pr-preview.yml`、cleanup含む）は、いずれも同じ `gh-pages` ブランチへ force-push します。しかし両者の `concurrency` group が別々だったため同時に実行され、gh-pages への push が競合していました。

実際に PR #48 のマージ時、gh-pages のコミット履歴は次の通りで、最後の本番デプロイ（`deploy: 86371ec`）後に `pr-47/` が消失していました（`keep_files: true` でも救えていない）。

```
e748b84 12:10:32 deploy: 86371ec        ← 本番デプロイ（このあと pr-47 が消失）
2fbf40b 12:10:06 chore: remove PR #48 preview
c900f1c 12:06:32 deploy: c083b08        ← #48 プレビュー
8f3407b 11:37:19 deploy: ef7f872        ← #47 プレビュー（pr-47 作成）
```

複数ワークフローが同一ブランチへ並行して force-push すると、片方の更新が失われます。

## 変更内容

`deploy.yml` と `pr-preview.yml` の `concurrency` group を共通の `gh-pages-deploy`（`cancel-in-progress: false`）に統一し、gh-pages へ書き込むワークフローを直列化しました。

- 同時 push による競合がなくなり、本番デプロイは最新の gh-pages（`pr-*` を含む）を取得したうえで `keep_files: true` によりプレビューを保持します。
- `cancel-in-progress: false` により、push 途中でのジョブ中断による不整合も防ぎます。

## 補足

- 直列化により、本番デプロイ・各PRプレビューのデプロイは同時実行されず順番待ちになります（gh-pages の一貫性を優先するための意図的な挙動です）。
- 本修正はデプロイパイプラインのみの変更で、アプリのコードには影響しません。

https://claude.ai/code/session_01WJP9qHcndLdYz2w9kfdt5v

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJP9qHcndLdYz2w9kfdt5v)_