### PR TITLE
一覧の本文プレビューを1行表示に変更

### DIFF
--- a/src/components/MemoList.tsx
+++ b/src/components/MemoList.tsx
@@ -318,10 +318,9 @@ const styles = `
   font-size: 0.82rem;
   color: var(--app-text-secondary);
   line-height: 1.45;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+  white-space: nowrap;
   overflow: hidden;
+  text-overflow: ellipsis;
   transition: color 0.3s;
 }
 `


### PR DESCRIPTION
## 概要
メモ一覧の本文プレビューを1行のみの表示に変更しました。それに伴い、行が短くなることで各アイテムの高さも自動的に調整されます。

## 変更内容
- `.memo-preview` を従来の2行表示(`-webkit-line-clamp: 2`)から、`white-space: nowrap` + `text-overflow: ellipsis` による1行表示に変更
- 1行に収まらない本文は末尾を省略記号(…)で表示
- プレビューが1行になることでアイテムの高さも縮小・調整される

https://claude.ai/code/session_01LTqpsENF1qfC8w4qAaGAtf

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTqpsENF1qfC8w4qAaGAtf)_