### PR TITLE
メモのピン留め機能を追加

### DIFF
--- a/src/components/MemoList.tsx
+++ b/src/components/MemoList.tsx
@@ -134,13 +134,13 @@ function MemoListItem({ memo, active, isOpen, suppressClickRef, onSelect, onDele
         onPointerCancel={endDrag}
       >
         <div className="memo-item-inner">
-          {memo.isPinned && (
-            <span className="pin-icon" aria-label="ピン留め">
+          <span className="pin-icon" aria-label={memo.isPinned ? 'ピン留め' : undefined}>
+            {memo.isPinned && (
               <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M16 12V4h1V2H7v2h1v8l-2 2v2h5.2v6h1.6v-6H18v-2l-2-2z" />
               </svg>
-            </span>
-          )}
+            )}
+          </span>
           <div className="memo-content">
             <h3 className="memo-title">{memo.title || '無題のメモ'}</h3>
             <p className="memo-preview">{getPreview(memo.content)}</p>
@@ -292,9 +292,11 @@ const styles = `
 .pin-icon {
   color: #667eea;
   flex-shrink: 0;
+  width: 16px;
   margin-top: 2px;
   display: flex;
   align-items: center;
+  justify-content: center;
 }
 
 .memo-content {

--- a/src/contexts/MemoContext.tsx
+++ b/src/contexts/MemoContext.tsx
@@ -147,11 +147,16 @@ export function MemoProvider({ children }: { children: ReactNode }) {
 
   async function updateMemo(userId: string, id: string, input: UpdateMemoInput): Promise<void> {
     const ref = doc(db, 'users', userId, 'memos', id)
-    const data: Record<string, unknown> = { updatedAt: Timestamp.now() }
+    const data: Record<string, unknown> = {}
     if (input.title !== undefined) data.title = input.title
     if (input.content !== undefined) data.content = input.content
     if ('category' in input) {
       data.category = input.category !== undefined ? input.category : deleteField()
+    }
+    if (input.isPinned !== undefined) data.isPinned = input.isPinned
+    // ピン留めの切り替えだけでは更新日時を変えない（内容変更時のみ更新）
+    if (input.title !== undefined || input.content !== undefined || 'category' in input) {
+      data.updatedAt = Timestamp.now()
     }
     await updateDoc(ref, data)
   }

--- a/src/views/MemoView.tsx
+++ b/src/views/MemoView.tsx
@@ -88,6 +88,14 @@ export default function MemoView() {
     }
   }
 
+  async function handleTogglePin() {
+    setShowMenu(false)
+    if (!currentUser || !memoStore.selectedMemo) return
+    await memoStore.updateMemo(currentUser.uid, memoStore.selectedMemo.id, {
+      isPinned: !memoStore.selectedMemo.isPinned
+    })
+  }
+
   async function handleLogout() {
     await logout()
     navigate('/login')
@@ -189,6 +197,25 @@ export default function MemoView() {
               </button>
               {showMenu && (
                 <div className="action-menu" onClick={e => e.stopPropagation()}>
+                  <button className="action-menu-item" onClick={handleTogglePin}>
+                    {memoStore.selectedMemo?.isPinned ? (
+                      <>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                          <line x1="2" y1="2" x2="22" y2="22"/>
+                          <path d="M9 4h6v1.5l-1 1.5M16 12V4h1V2H7"/>
+                          <path d="M8 12l-2 2v2h7.2M14 16v6"/>
+                        </svg>
+                        ピン留めを解除
+                      </>
+                    ) : (
+                      <>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                          <path d="M16 12V4h1V2H7v2h1v8l-2 2v2h5.2v6h1.6v-6H18v-2l-2-2z"/>
+                        </svg>
+                        ピン留め
+                      </>
+                    )}
+                  </button>
                   <button className="action-menu-item action-menu-delete" onClick={handleDeleteFromMenu}>
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                       <polyline points="3 6 5 6 21 6"/>


### PR DESCRIPTION
## 概要
メモをピン留めできるようにしました。編集画面の「その他」メニューに項目を追加しています。

## 変更点
- 編集画面（エディタ右上）の「その他」メニューに **「ピン留め」/「ピン留めを解除」** の項目を追加
- `updateMemo` で `isPinned` の更新に対応
- ピン留めの切り替えだけでは更新日時（`updatedAt`）を変更しないように調整（並び順・表示が乱れないため）

## 補足
ピン留めされたメモは一覧の先頭に表示され、ピンアイコンが付きます（並べ替え・一覧アイコン・型定義は既存実装を利用）。

## 動作確認
- `npm run build` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1PAFDQtBwgVYNoUUUSPQe)_